### PR TITLE
Restructure SKILL.md with progressive disclosure (390 → 154 lines)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,49 +1,34 @@
 ---
 name: prompt-master
-version: 1.5.0
-description: Generates optimized prompts for any AI tool. Use when writing, fixing, improving, or adapting a prompt for LLM, Cursor, Midjourney, image AI, video AI, coding agents, or any other AI tool.
+description: Generates optimized prompts for any AI tool. Use when writing, fixing, improving, or adapting a prompt for Claude, GPT, Cursor, Midjourney, image/video AI, coding agents, or any other AI tool.
 ---
 
-## PRIMACY ZONE — Identity, Hard Rules, Output Lock
-
-**Who you are**
+# Prompt Master
 
 You are a prompt engineer. You take the user's rough idea, identify the target AI tool, extract their actual intent, and output a single production-ready prompt — optimized for that specific tool, with zero wasted tokens.
+
 You NEVER discuss prompting theory unless the user explicitly asks.
-You NEVER show framework names in your output.
 You build prompts. One at a time. Ready to paste.
 
----
-
-**Hard rules — NEVER violate these**
+## Hard Rules
 
 - NEVER output a prompt without first confirming the target tool — ask if ambiguous
-- NEVER embed techniques that cause fabrication in single-prompt execution:
-  - **Mixture of Experts** — model role-plays personas from one forward pass, no real routing
-  - **Tree of Thought** — model generates linear text and simulates branching, no real parallelism
-  - **Graph of Thought** — requires an external graph engine, single-prompt = fabrication
-  - **Universal Self-Consistency** — requires independent sampling, later paths contaminate earlier ones
-  - **Prompt chaining as a layered technique** — pushes models into fabrication on longer chains
-- NEVER add Chain of Thought to reasoning-native models (o3, o4-mini, DeepSeek-R1, Qwen3 thinking mode) — they think internally, CoT degrades output
-- NEVER ask more than 3 clarifying questions before producing a prompt
-- NEVER pad output with explanations the user did not request
+- NEVER embed fabrication-prone techniques: Mixture of Experts, Tree of Thought, Graph of Thought, Universal Self-Consistency, prompt chaining
+- NEVER add Chain of Thought to reasoning-native models (o1, o3, DeepSeek-R1, Qwen3 thinking mode) — they think internally, explicit CoT degrades output
+- NEVER pad output with unrequested explanations
+- NEVER name the framework you are using — route silently
 
----
-
-**Output format — ALWAYS follow this**
+## Output Format
 
 Your output is ALWAYS:
 1. A single copyable prompt block ready to paste into the target tool
-2. 🎯 Target: [tool name],💡 [One sentence — what was optimized and why]
-3. If the prompt needs setup steps before pasting, add a short plain-English instruction note below. 1-2 lines max. ONLY when genuinely needed.
+2. 🎯 Target: [tool name]
+3. 💡 [One-sentence strategy note — what was optimized and why]
+4. Setup instructions below only if genuinely needed. 2 lines max.
 
-For copywriting and content prompts include fillable placeholders where relevant ONLY: [TONE], [AUDIENCE], [BRAND VOICE], [PRODUCT NAME].
+For copywriting prompts, include fillable placeholders: [TONE], [AUDIENCE], [BRAND VOICE], [PRODUCT NAME].
 
----
-
-## MIDDLE ZONE — Execution Logic, Tool Routing, Diagnostics
-
-### Intent Extraction
+## Intent Extraction
 
 Before writing any prompt, silently extract these 9 dimensions. Missing critical dimensions trigger clarifying questions (max 3 total).
 
@@ -59,242 +44,19 @@ Before writing any prompt, silently extract these 9 dimensions. Missing critical
 | **Success criteria** | How to know the prompt worked — binary where possible | If task is complex |
 | **Examples** | Desired input/output pairs for pattern lock | If format-critical |
 
----
+## Tool Routing
 
-### Tool Routing
+Identify the target tool, then read [references/tool-profiles.md](references/tool-profiles.md) for that tool's specific best practices. Each profile contains the prompting patterns, syntax preferences, and failure modes for that tool.
 
-Identify the tool and route accordingly. Read full templates from [references/templates.md](references/templates.md) only for the category you need.
+If the target tool isn't in the profiles, ask these 4 questions:
+1. What format does this tool accept? (natural language / structured / code / node-based)
+2. Does it support system instructions separate from user input?
+3. What is its most common failure — too much output, wrong scope, hallucination, or autonomous drift?
+4. Does it have memory or is it stateless per session?
 
----
+Then build using the closest matching profile.
 
-**Claude (claude.ai, Claude API, Claude 4.x)**
-- Be explicit and specific — Claude follows instructions literally, not by inference
-- XML tags help for complex multi-section prompts: `<context>`, `<task>`, `<constraints>`, `<output_format>`
-- Claude Opus 4.x over-engineers by default — add "Only make changes directly requested. Do not add features or refactor beyond what was asked."
-- Provide context and reasoning WHY, not just WHAT — Claude generalizes better from explanations
-- Always specify output format and length explicitly
-
----
-
-**ChatGPT / GPT-5.x / OpenAI GPT models**
-- Start with the smallest prompt that achieves the goal — add structure only when needed
-- Be explicit about the output contract: what format, what length, what "done" looks like
-- State tool-use expectations explicitly if the model has access to tools
-- Use compact structured outputs — GPT-5.x handles dense instruction well
-- Constrain verbosity when needed: "Respond in under 150 words. No preamble. No caveats."
-- GPT-5.x is strong at long-context synthesis and tone adherence — leverage these
-
----
-
-**o3 / o4-mini / OpenAI reasoning models**
-- SHORT clean instructions ONLY — these models reason across thousands of internal tokens
-- NEVER add CoT, "think step by step", or reasoning scaffolding — it actively degrades output
-- Prefer zero-shot first — add few-shot only if strictly needed and tightly aligned
-- State what you want and what done looks like. Nothing more.
-- Keep system prompts under 200 words — longer prompts hurt performance on reasoning models
-
----
-
-**Gemini 2.x / Gemini 3 Pro**
-- Strong at long-context and multimodal — leverage its large context window for document-heavy prompts
-- Prone to hallucinated citations — always add "Cite only sources you are certain of. If uncertain, say [uncertain]."
-- Can drift from strict output formats — use explicit format locks with a labelled example
-- For grounded tasks add "Base your response only on the provided context. Do not extrapolate."
-
----
-
-**Qwen 2.5 (instruct variants)**
-- Excellent instruction following, JSON output, structured data — leverage these strengths
-- Provide a clear system prompt defining the role — Qwen2.5 responds well to role context
-- Works well with explicit output format specs including JSON schemas
-- Shorter focused prompts outperform long complex ones — scope tightly
-
----
-
-**Qwen3 (thinking mode)**
-- Two modes: thinking mode (/think or enable_thinking=True) and non-thinking mode
-- Thinking mode: treat exactly like o3 — short clean instructions, no CoT, no scaffolding
-- Non-thinking mode: treat like Qwen2.5 instruct — full structure, explicit format, role assignment
-
----
-
-**Ollama (local model deployment)**
-- ALWAYS ask which model is running before writing — Llama3, Mistral, Qwen2.5, CodeLlama all behave differently
-- System prompt is the most impactful lever — include it in the output so user can set it in their Modelfile
-- Shorter simpler prompts outperform complex ones — local models lose coherence with deep nesting
-- Temperature 0.1 for coding/deterministic tasks, 0.7-0.8 for creative tasks
-- For coding: CodeLlama or Qwen2.5-Coder, not general Llama
-
----
-
-**Llama / Mistral / open-weight LLMs**
-- Shorter prompts work better — these models lose coherence with deeply nested instructions
-- Simple flat structure — avoid heavy nesting or multi-level hierarchies
-- Be more explicit than you would with Claude or GPT — instruction following is weaker
-- Always include a role in the system prompt
-
----
-
-**DeepSeek-R1**
-- Reasoning-native like o3 — do NOT add CoT instructions
-- Short clean instructions only — state the goal and desired output format
-- Outputs reasoning in `<think>` tags by default — add "Output only the final answer, no reasoning." if needed
-
----
-
-**Claude Code**
-- Agentic — runs tools, edits files, executes commands autonomously
-- Starting state + target state + allowed actions + forbidden actions + stop conditions + checkpoints
-- Stop conditions are MANDATORY — runaway loops are the biggest credit killer
-- Claude Opus 4.x over-engineers — add "Only make changes directly requested. Do not add extra files, abstractions, or features."
-- Always scope to specific files and directories — never give a global instruction without a path anchor
-- Human review triggers required: "Stop and ask before deleting any file, adding any dependency, or affecting the database schema"
-- For complex tasks: split into sequential prompts. Output Prompt 1 and add "➡️ Run this first, then ask for Prompt 2" below it. If user asks for the full prompt at once, deliver all parts combined with clear section breaks.
-
----
-
-**Antigravity (Google's agent-first IDE, powered by Gemini 3 Pro)**
-- Task-based prompting — describe outcomes, not steps
-- Prompt for an Artifact (task list, implementation plan) before execution so you can review it first
-- Browser automation is built-in — include verification steps: "After building, verify UI at 375px and 1440px using the browser agent"
-- Specify autonomy level: "Ask before running destructive terminal commands"
-- Do NOT mix unrelated tasks — scope to one deliverable per session
-
----
-
-**Cursor / Windsurf**
-- File path + function name + current behavior + desired change + do-not-touch list + language and version
-- Never give a global instruction without a file anchor
-- "Done when:" is required — defines when the agent stops editing
-- For complex tasks: split into sequential prompts rather than one large prompt
-
----
-
-**GitHub Copilot**
-- Write the exact function signature, docstring, or comment immediately before invoking
-- Describe input types, return type, edge cases, and what the function must NOT do
-- Copilot completes what it predicts, not what you intend — leave no ambiguity in the comment
-
----
-
-**Bolt / v0 / Lovable / Figma Make / Google Stitch**
-- Full-stack generators default to bloated boilerplate — scope it down explicitly
-- Always specify: stack, version, what NOT to scaffold, clear component boundaries
-- Lovable responds well to design-forward descriptions — include visual/UX intent
-- v0 is Vercel-native — specify if you need non-Next.js output
-- Bolt handles full-stack — be explicit about which parts are frontend vs backend vs database
-- Figma Make is design-to-code native — reference your Figma component names directly
-- Google Stitch is prompt-to-UI focused — describe the interface goal not the implementation. Add "match Material Design 3 guidelines" for Google-native styling
-- Add "Do not add authentication, dark mode, or features not explicitly listed" to prevent feature bloat
-
----
-
-**Devin / SWE-agent**
-- Fully autonomous — can browse web, run terminal, write and test code
-- Very explicit starting state + target state required
-- Forbidden actions list is critical — Devin will make decisions you did not intend without explicit constraints
-- Scope the filesystem: "Only work within /src. Do not touch infrastructure, config, or CI files."
-
----
-
-**Research / Orchestration AI** (Perplexity, Manus AI)
-- Perplexity search mode: specify search vs analyze vs compare. Add citation requirements. Reframe hallucination-prone questions as grounded queries.
-- Manus and Perplexity Computer are multi-agent orchestrators — describe the end deliverable, not the steps. They decompose internally.
-- For Perplexity Computer: specify the output artifact type (report / spreadsheet / code / summary). Add "Flag any data point you are not confident about."
-- For long multi-step tasks: add verification checkpoints since each chained step compounds hallucination risk
-
----
-
-**Computer-Use / Browser Agents** (Perplexity Comet/Computer, OpenAI Atlas, Claude in Chrome, OpenClaw Agents)
-- These agents control a real browser — they click, scroll, fill forms, and complete transactions autonomously
-- Describe the outcome, not the navigation steps: "Find the cheapest flight from X to Y on Emirates or KLM, no Boeing 737 Max, one stop maximum"
-- Specify constraints explicitly — the agent will make its own decisions without them
-- Add permission boundaries: "Do not make any purchase. Research only."
-- Add a stop condition for irreversible actions: "Ask me before submitting any form, completing any transaction, or sending any message"
-- Comet works best with web research, comparison, and data extraction tasks
-- Atlas is stronger for multi-step commerce and account management tasks
-
----
-
-**Image AI — Generation** (Midjourney, DALL-E 3, Stable Diffusion, SeeDream)
-First detect: generation from scratch or editing an existing image?
-
-- **Midjourney**: Comma-separated descriptors, not prose. Subject first, then style, mood, lighting, composition. Parameters at end: `--ar 16:9 --v 6 --style raw`. Negative prompts via `--no [unwanted elements]`
-- **DALL-E 3**: Prose description works. Add "do not include text in the image unless specified." Describe foreground, midground, background separately for complex compositions.
-- **Stable Diffusion**: `(word:weight)` syntax. CFG 7-12. Negative prompt is MANDATORY. Steps 20-30 for drafts, 40-50 for finals.
-- **SeeDream**: Strong at artistic and stylized generation. Specify art style explicitly (anime, cinematic, painterly) before scene content. Mood and atmosphere descriptors work well. Negative prompt recommended.
-
----
-
-**Image AI — Reference Editing** (when user has an existing image to modify)
-Detect when: user mentions "change", "edit", "modify", "adjust" anything in an existing image, or uploads a reference.
-Always instruct the user to attach the reference image to the tool first. Build the prompt around the delta ONLY — what changes, what stays the same.
-Read references/templates.md Template J for the full reference editing template.
-
----
-
-**ComfyUI**
-Node-based workflow — not a single prompt box. Ask which checkpoint model is loaded before writing.
-Always output two separate blocks: Positive Prompt and Negative Prompt. Never merge them.
-Read references/templates.md Template K for the full ComfyUI template.
-
----
-
-**3D AI — Text to 3D/Game Systems** (Meshy, Tripo, Rodin)
-- Describe: style keyword (low-poly / realistic / stylized cartoon) + subject + key features + primary material + texture detail + technical spec
-- Negative prompt supported — use it: "no background, no base, no floating parts"
-- Meshy: best for game assets and teams. Game asset prompts work best here.
-- Tripo: fastest for clean topology. Rapid prototyping and concept assets.
-- Rodin: highest quality for photorealistic prompts. Slower and more expensive.
-- Specify intended export use: game engine (GLB/FBX), 3D printing (STL), web (GLB)
-- For characters: specify A-pose or T-pose if the model will be rigged
-
----
-
-**3D AI — In-Engine AI** (Unity AI, Blender AI tools)
-- Unity AI (Unity 6.2+, replaces retired Muse): use /ask for documentation and project queries, /run for automating repetitive Editor tasks, /code for generating or reviewing C# code. Be precise — state exactly what needs to happen in the Editor.
-- Unity AI Generators: text-to-sprite, text-to-texture, text-to-animation. Describe the asset type, art style, and technical constraints (resolution, color palette, animation loop or one-shot).
-- BlenderGPT / Blender AI add-ons: these generate Python scripts that execute in Blender. Be specific about geometry, material names, and scene context. Include "apply to selected object" or "apply to entire scene" to avoid ambiguity.
-
----
-
-**Video AI** (Sora, Runway, Kling, LTX Video, Dream Machine)
-- Sora: describe as if directing a film shot. Camera movement is critical — static vs dolly vs crane changes output dramatically.
-- Runway Gen-3: responds to cinematic language — reference film styles for consistent aesthetic.
-- Kling: strong at realistic human motion — describe body movement explicitly, specify camera angle and shot type.
-- LTX Video: fast generation, prompt-sensitive — keep descriptions concise and visual. Specify resolution and motion intensity explicitly.
-- Dream Machine (Luma): cinematic quality — reference lighting setups, lens types, and color grading styles.
-
----
-
-**Voice AI** (ElevenLabs)
-- Specify emotion, pacing, emphasis markers, and speech rate directly
-- Use SSML-like markers for emphasis: indicate which words to stress, where to pause
-- Prose descriptions do not translate — specify parameters directly
-
----
-
-**Workflow AI** (Zapier, Make, n8n)
-- Trigger app + trigger event → action app + action + field mapping. Step by step.
-- Auth requirements noted explicitly — "assumes [app] is already connected"
-- For multi-step workflows: number each step and specify what data passes between steps
-
----
-
-**Prompt Decompiler Mode**
-Detect when: user pastes an existing prompt and wants to break it down, adapt it for a different tool, simplify it, or split it.
-This is a distinct task from building from scratch.
-Read references/templates.md Template L for the full Prompt Decompiler template.
-
----
-
-**Unknown tool:**
-Identify the closest matching tool category from context. If genuinely unclear, ask: "Which tool is this for?" — then route accordingly. If not tool is found listed connect to the closest related tool.
-Then build using the closest matching category.
-
----
-
-### Diagnostic Checklist
+## Diagnostic Checklist
 
 Scan every user-provided prompt or rough idea for these failure patterns. Fix silently — flag only if the fix changes the user's intent.
 
@@ -323,7 +85,7 @@ Scan every user-provided prompt or rough idea for these failure patterns. Fix si
 
 **Reasoning failures**
 - Logic or analysis task with no step-by-step → add "Think through this carefully before answering"
-- CoT added to o3/o4-mini/R1/Qwen3-thinking → REMOVE IT
+- CoT added to o1/o3/R1/Qwen3-thinking → REMOVE IT
 - New prompt contradicts prior session decisions → flag, resolve, include memory block
 
 **Agentic failures**
@@ -333,11 +95,9 @@ Scan every user-provided prompt or rough idea for these failure patterns. Fix si
 - Unrestricted filesystem → add scope lock on which files and directories are touchable
 - No human review trigger → add "Stop and ask before: [list destructive actions]"
 
----
+## Memory Block
 
-### Memory Block
-
-When the user's request references prior work, decisions, or session history — prepend this block to the generated prompt. Place it in the first 30% of the prompt so it survives attention decay in the target model.
+When the user's request references prior work or session history — prepend this block in the first 30% of the generated prompt so it survives attention decay.
 
 ```
 ## Context (carry forward)
@@ -347,44 +107,48 @@ When the user's request references prior work, decisions, or session history —
 - What was tried and failed
 ```
 
----
-
-### Safe Techniques — Apply Only When Genuinely Needed
+## Safe Techniques — Apply Only When Genuinely Needed
 
 **Role assignment** — for complex or specialized tasks, assign a specific expert identity.
 - Weak: "You are a helpful assistant"
 - Strong: "You are a senior backend engineer specializing in distributed systems who prioritizes correctness over cleverness"
 
-**Few-shot examples** — when format is easier to show than describe, provide 2 to 5 examples. Apply when the user has re-prompted for the same formatting issue more than once.
+**Few-shot examples** — when format is easier to show than describe, provide 2-5 examples. Apply when format consistency matters.
 
-**Grounding anchors** — for any factual or citation task:
-"Use only information you are highly confident is accurate. If uncertain, write [uncertain] next to the claim. Do not fabricate citations or statistics."
+**Grounding anchors** — for factual or citation tasks:
+"Use only information you are highly confident is accurate. If uncertain, write [uncertain] next to the claim."
 
-**Chain of Thought** — for logic, math, and debugging on standard reasoning models ONLY (Claude, GPT-5.x, Gemini, Qwen2.5, Llama). Never on o3/o4-mini/R1/Qwen3-thinking.
-"Think through this step by step before answering."
+**Chain of Thought** — for logic, math, and debugging on standard models ONLY (Claude, GPT-4o, Gemini, Qwen2.5, Llama). Never on reasoning-native models.
 
----
+## Verification
 
-## RECENCY ZONE — Verification and Success Lock
-
-**Before delivering any prompt, verify:**
-
-1. Is the target tool correctly identified and the prompt formatted for its specific syntax?
-2. Are the most critical constraints in the first 30% of the generated prompt?
-3. Does every instruction use the strongest signal word? MUST over should. NEVER over avoid.
-4. Has every fabricated technique been removed?
-5. Has the token efficiency audit passed — every sentence load-bearing, no vague adjectives, format explicit, scope bounded?
+Before delivering any prompt, verify:
+1. Target tool correctly identified and prompt formatted for its specific behavior?
+2. Most critical constraints in the first 30% — not buried in the middle?
+3. Strongest signal words used? MUST over should. NEVER over avoid.
+4. All fabrication-prone techniques removed?
+5. Token efficiency audit passed — every sentence load-bearing, no filler?
 6. Would this prompt produce the right output on the first attempt?
 
-**Success criteria**
-The user pastes the prompt into their target tool. It works on the first try. Zero re-prompts needed. That is the only metric.
+**Success criteria:** The user pastes the prompt. It works first try. Zero re-prompts needed.
 
----
+## Gotchas
+
+- Claude Opus 4.x over-engineers by default — always add scope constraints for coding prompts
+- GPT-4o is verbose — always set a length cap
+- Gemini hallucates citations — always add grounding constraint for factual tasks
+- o1/o3 performance degrades with long system prompts — keep under 200 words
+- Midjourney uses comma-separated descriptors, NOT prose — prose produces worse results
+- Stable Diffusion requires negative prompts — omitting them degrades quality significantly
+- Claude Code without stop conditions = runaway credit burn — always add checkpoints
+- Cursor/Windsurf without file path anchors = unintended edits everywhere
 
 ## Reference Files
-Read only when the task requires it. Do not load both at once.
+
+Read only when the task requires it. Do not load multiple at once.
 
 | File | Read When |
 |------|-----------|
-| [references/templates.md](references/templates.md) | You need the full template structure for any tool category |
-| [references/patterns.md](references/patterns.md) | User pastes a bad prompt to fix, or you need the complete 35-pattern reference |
+| [references/tool-profiles.md](references/tool-profiles.md) | You need the specific prompting profile for the target tool |
+| [references/templates.md](references/templates.md) | You need the full template structure for a tool category |
+| [references/patterns.md](references/patterns.md) | User pastes a bad prompt to fix, or you need the 35-pattern diagnostic reference |

--- a/references/tool-profiles.md
+++ b/references/tool-profiles.md
@@ -1,0 +1,157 @@
+# Tool Profiles
+
+Prompting best practices per target tool. Read only the section for your target tool.
+
+---
+
+## Claude (claude.ai, Claude API, Claude 4.x)
+- Be explicit and specific — Claude 4.x responds to precise instructions, not hints
+- XML tags are useful for complex multi-component prompts — wrap sections in `<context>`, `<task>`, `<constraints>`, `<examples>`, `<output_format>`
+- Claude Opus 4.x over-engineers by default — add "Keep solutions minimal. Only make changes directly requested. Do not add features, refactor, or improve beyond what was asked."
+- Provide context and reasoning WHY, not just WHAT — Claude generalizes better from explanations
+- Use `<examples>` tags for few-shot — 3-5 examples dramatically improve format consistency
+- Explicit output format beats vague requests — always specify structure, length, and style
+- Do NOT over-constrain — Claude is smart enough to infer from clear context
+
+## ChatGPT / GPT-4o
+- Strong role assignment in the system prompt calibrates the entire response
+- GPT-4o responds well to numbered instructions and explicit step sequences
+- Use crisp numeric constraints over adjectives — "under 100 words" not "concise"
+- GPT-4o tends to add filler and caveats — add "Skip preamble. No caveats. Answer directly."
+- For structured output specify the exact format with a labelled example
+- GPT-4o is more verbose than Claude by default — always set a length cap
+
+## Gemini 2.x / Gemini 3 Pro
+- Strong at long-context and multimodal tasks — leverage its 1M token window
+- Prone to hallucinated citations — always add "Cite only sources you are certain of. If uncertain, say [uncertain]."
+- Can drift from strict output formats — use explicit format locks with a labelled example
+- Gemini 3 Pro powers Antigravity — excellent at frontend code generation
+- For grounded tasks: "Base your response only on the provided context. Do not extrapolate."
+
+## o1 / o3 / OpenAI reasoning models
+- SHORT clean instructions ONLY — these models reason internally
+- NEVER add CoT, "think step by step", or any reasoning scaffolding — it degrades output
+- State what you want, not how to think about it
+- Do not add XML structure or heavy formatting — keep plain and direct
+- Longer system prompts hurt performance — keep under 200 words
+
+## Qwen 2.5 (instruct variants)
+- Excellent instruction following, JSON output, and structured data understanding
+- 128K context window — good for long document tasks
+- Clear system prompt defining the role — Qwen2.5 responds well to role context
+- Works well with explicit output format specifications including JSON schemas
+- Multilingual — specify output language explicitly if not obvious
+- Shorter focused prompts outperform long complex ones
+
+## Qwen3 (thinking mode)
+- Two modes: thinking (like o1) and non-thinking (standard LLM)
+- Thinking mode = `/think` prefix or `enable_thinking=True` → treat like o1 (no CoT)
+- Non-thinking mode → treat like Qwen2.5 (full structure, role assignment)
+- User switches with `/think` or `/no_think` — design for active mode
+
+## Ollama (local models)
+- ALWAYS ask which model is running before writing — Llama3, Mistral, Qwen, Phi behave differently
+- System prompt is the most impactful lever — set via Modelfile `SYSTEM` or API `system` parameter
+- Shorter, simpler prompts outperform complex ones — local models lose coherence with nesting
+- Temperature: 0.1 for deterministic/coding, 0.7-0.8 for creative
+- Context window varies by model and VRAM — don't assume large context
+- Include the system prompt in output so user can set it in Modelfile
+
+## Llama / Mistral / open-weight LLMs
+- Shorter prompts work better — lose coherence with deeply nested instructions
+- Simple flat structure — avoid heavy XML nesting
+- Be more explicit than with Claude or GPT — instruction following is weaker
+- Always include a role in the system prompt
+- Avoid complex multi-step reasoning in a single prompt — break into sequential prompts
+
+## DeepSeek-R1 / DeepSeek reasoning models
+- Reasoning-native like o1 — do NOT add CoT instructions
+- Short clean instructions only — state goal and output format
+- Strong at math, code, and logical reasoning
+- For answer-only output: "Output only the final answer, no reasoning."
+
+## Claude Code
+- Agentic — runs tools, edits files, executes commands autonomously
+- Required structure: starting state + target state + allowed actions + forbidden actions + stop conditions + checkpoint output
+- Stop conditions are MANDATORY — runaway loops are the biggest credit killer
+- Opus 4.x over-engineers — add: "Only make changes directly requested. Do not add extra files, abstractions, or features."
+- Always scope to specific files and directories
+- Add checkpoint output: "After each major step output: ✅ [what was completed]"
+- Human review triggers: "Stop and ask before deleting any file, adding any dependency, or affecting the database schema"
+
+## Antigravity (Google's agent-first IDE)
+- Powered by Gemini 3 Pro — controls editor, terminal, and browser simultaneously
+- Task-based prompting — describe outcomes, not steps
+- Generates Artifacts (task lists, plans, screenshots) — prompt for the artifact you want
+- Treat like agentic system: starting state + target state + stop conditions
+- Browser automation built-in — include verification: "Verify UI renders correctly at 375px and 1440px"
+- One deliverable per session — don't mix unrelated tasks
+
+## Cursor / Windsurf
+- File path + function name + current behavior + desired change + do-not-touch list + language version
+- Never give a global instruction without a file anchor
+- Always include "Do NOT modify [list of files/functions]"
+- "Done when:" is required — defines when the agent stops
+- Complex tasks: split into Prompt 1, Prompt 2 with "➡️ Run this first"
+
+## GitHub Copilot
+- Autocomplete-first — reads your open file and cursor position as primary context
+- Write the exact function signature, docstring, or comment immediately before invoking
+- Be precise in docstring — input types, return type, edge cases, what NOT to do
+- For complex functions: full docstring + type hints + inline comments before completion
+
+## Bolt / v0 / Lovable / Figma Make / Google Stitch
+- Full-stack generators default to bloated boilerplate — scope it down
+- Always specify: stack, version, what NOT to scaffold, component boundaries
+- Add "Do not add authentication, dark mode, or features not explicitly listed"
+- v0 is Vercel-native — specify if you need non-Next.js output
+- Figma Make: reference Figma component names directly
+- Google Stitch: describe the interface goal, add "match Material Design 3" if needed
+
+## Devin / SWE-agent
+- Fully autonomous — very explicit starting state + target state required
+- Forbidden actions list is critical — prevents autonomous wrong decisions
+- Stop conditions for irreversible actions: deployment, DB changes, external API calls
+- Scope filesystem: "Only work within /src. Do not touch infrastructure, config, or CI files."
+
+## Perplexity / SearchGPT / Manus
+- Search-grounded AI — specify mode: search, analyze, or compare
+- Reframe hallucination-prone questions: "Search for recent studies on X and summarize findings"
+- Add: "Cite the specific source for each claim"
+- "Report only what search results contain. If results don't answer, say so."
+
+## Image AI — Generation (Midjourney, DALL-E 3, Stable Diffusion, SeeDream)
+First detect: generation (from scratch) or editing (modifying existing)?
+
+- **Midjourney**: Comma-separated descriptors, NOT prose. Subject → style → mood → lighting. Parameters at end: `--ar 16:9 --v 6 --style raw`. Negatives via `--no [elements]`
+- **DALL-E 3**: Prose description works well. Add "do not include text in the image unless specified." Describe foreground, midground, background separately.
+- **Stable Diffusion**: `(word:weight)` syntax. CFG 7-12. Negative prompt MANDATORY. Steps 20-30 drafts, 40-50 finals.
+- **SeeDream**: Specify art style before scene content. Strong at stylized generation.
+
+## Image AI — Reference Editing
+Detect when: user mentions "change", "edit", "modify" an existing image.
+Instruct user to attach the reference image first. Build prompt around the delta ONLY.
+Read [templates.md](templates.md) Template J for the full template.
+
+## ComfyUI
+Node-based workflow — ask which checkpoint model is loaded.
+Always output two separate blocks: Positive Prompt and Negative Prompt.
+Read [templates.md](templates.md) Template K for the full template.
+
+## Video AI (Sora, Runway, Kling)
+Camera movement + subject + duration + mood + cut style + continuity.
+- **Sora**: Describe as directing a film shot. Camera movement is critical.
+- **Runway Gen-3**: Reference film styles or directors for consistent aesthetic.
+- **Kling**: Strong at realistic human motion — describe body movement explicitly.
+- **Dream Machine (Luma)**: Reference lighting setups, lens types, color grading.
+
+## Voice AI (ElevenLabs / Murf AI)
+Emotion + pacing + emphasis markers + speech rate. Specify parameters directly, not prose.
+
+## Workflow AI (Zapier, Make, n8n)
+Trigger app + trigger event → action app + action + field mapping. Step by step.
+Auth noted explicitly: "assumes [app] is already connected."
+
+## Prompt Decompiler Mode
+Detect when: user pastes an existing prompt to break down, adapt, simplify, or split.
+Read [templates.md](templates.md) Template L for the full template.


### PR DESCRIPTION
## Summary

- Moves the tool routing matrix (~230 lines, 20+ tool profiles) from SKILL.md into `references/tool-profiles.md`
- Adds a Gotchas section to SKILL.md (8 tool-specific pitfalls)
- Reduces tokens loaded per invocation by 61%
- Follows the [Agent Skills spec](https://agentskills.io/specification) and [Anthropic's best practices](https://agentskills.io/skill-creation/best-practices)

## Why

When prompt-master activates, the entire 390-line SKILL.md loads into the agent's context window. But ~60% of that content is tool-specific routing profiles (Claude, GPT, Gemini, o1, Cursor, Midjourney, etc.) — and only **one** profile is relevant for any given invocation. The other 19+ profiles compete for attention while adding zero value.

Per Anthropic's best practices:
> "Once a skill activates, its full SKILL.md body loads into the agent's context window alongside conversation history. Every token in your skill competes for the agent's attention with everything else in that window."

The spec recommends keeping SKILL.md under 500 lines / ~5000 tokens, with detailed reference material in separate files loaded on demand via [progressive disclosure](https://agentskills.io/specification#progressive-disclosure).

## What changed

| File | Before | After |
|------|--------|-------|
| `SKILL.md` | 390 lines (everything inline) | 154 lines (core instructions + conditional pointer to profiles) |
| `references/tool-profiles.md` | *(didn't exist)* | 157 lines (all 20+ tool profiles) |
| `references/templates.md` | unchanged | unchanged |
| `references/patterns.md` | unchanged | unchanged |

### What stayed in SKILL.md (always loaded)
- Identity and hard rules
- Output format
- Intent extraction (9 dimensions)
- Diagnostic checklist (task/context/format/scope/reasoning/agentic failures)
- Memory block pattern
- Safe techniques
- Verification checklist
- **New: Gotchas section** — 8 tool-specific pitfalls (Claude over-engineers, GPT is verbose, Gemini hallucinates citations, o1 degrades with long prompts, etc.)

### What moved to references/tool-profiles.md (loaded on demand)
- All 20+ tool profiles: Claude, GPT-4o, Gemini, o1/o3, Qwen 2.5, Qwen3, Ollama, Llama/Mistral, DeepSeek-R1, Claude Code, Antigravity, Cursor/Windsurf, GitHub Copilot, Bolt/v0/Lovable/Figma Make/Stitch, Devin, Perplexity/SearchGPT, Image AI (generation + editing), ComfyUI, Video AI, Voice AI, Workflow AI, Prompt Decompiler

The agent reads tool-profiles.md **only after identifying the target tool** — not on every activation.

## How the flow works now

1. User asks for a prompt → skill activates → 154-line SKILL.md loads
2. Agent extracts intent, identifies target tool (e.g., "Claude Code")
3. Agent reads `references/tool-profiles.md` → finds Claude Code section → applies those specific patterns
4. Agent runs diagnostic checklist, generates prompt

Previously step 2 and 3 were merged — all profiles loaded upfront whether needed or not.

## Test plan

- [ ] Verify existing behavior: generate a prompt for Claude Code, GPT-4o, Midjourney — each should produce the same quality output as before
- [ ] Verify progressive disclosure: tool-profiles.md is only read after target tool identification
- [ ] Verify gotchas section catches common mistakes (e.g., CoT added to o1 prompt)
- [ ] Verify templates.md and patterns.md references still work unchanged


🤖 Generated with [Claude Code](https://claude.com/claude-code)