### PR TITLE
feat: add MiniMax (M2.7/M2.5) as recognized AI tool target

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Claude skill that writes the accurate prompts for any AI tool. Zero tokens or credits wasted. Full context and memory retention. No re-prompting your way to an answer you should have gotten on attempt one.
 
-**Works with:** Claude, ChatGPT, Gemini, o1/o3, Cursor, Claude Code, GitHub Copilot, Windsurf, Bolt, v0, Lovable, Devin, Perplexity, Midjourney, DALL-E, Stable Diffusion, ComfyUI, Sora, Runway, ElevenLabs, Zapier, Make, and any AI tool you throw at it.
+**Works with:** Claude, ChatGPT, Gemini, o1/o3, MiniMax, Cursor, Claude Code, GitHub Copilot, Windsurf, Bolt, v0, Lovable, Devin, Perplexity, Midjourney, DALL-E, Stable Diffusion, ComfyUI, Sora, Runway, ElevenLabs, Zapier, Make, and any AI tool you throw at it.
 
 ---
 
@@ -208,6 +208,7 @@ Prompt Master includes specific profiles for 20+ tools. For anything not on the 
 | **Qwen 2.5 / Qwen3** | Open-weight LLM | Chat template format, thinking vs non-thinking mode detection |
 | **Local models (Llama, Mistral)** | Open-weight LLM | Shorter prompts, simpler structure, no complex nesting |
 | **DeepSeek-R1** | Reasoning LLM | Short clean instructions, strips CoT, suppresses thinking output if needed |
+| **MiniMax (M2.7 / M2.5)** | Reasoning LLM | Temperature clamping, thinking tag control, structured output optimization |
 | **Claude Code** | Agentic AI | Stop conditions, file scope, checkpoint output |
 | **Cursor / Windsurf** | IDE AI | File path, function name, do-not-touch list, sequential prompt guidance |
 | **GitHub Copilot** | Autocomplete AI | Exact function contract as docstring |

--- a/SKILL.md
+++ b/SKILL.md
@@ -142,6 +142,18 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
+**MiniMax (M2.7 / M2.5)**
+- OpenAI-compatible API — prompts that work with GPT models transfer directly
+- Strong at instruction following, structured output, and long-context synthesis — 1M context window on M2.7
+- M2.5-highspeed has a 204K context window and is optimized for speed — use for latency-sensitive tasks
+- Temperature must be between 0 and 1 (inclusive) — prompts that set temperature above 1 will fail
+- May output reasoning in `<think>` tags — add "Output only the final answer, no reasoning tags." if the user does not want visible thinking
+- Good at code generation, JSON output, and multi-step analysis — leverage these strengths
+- Responds well to explicit role assignment and structured prompts with clear output format specifications
+- For function calling: supports OpenAI-style tool definitions — include tool schemas directly
+
+---
+
 **Claude Code**
 - Agentic — runs tools, edits files, executes commands autonomously
 - Starting state + target state + allowed actions + forbidden actions + stop conditions + checkpoints


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimax.io/) M2.7 and M2.5 models as a recognized AI tool in Prompt Master's routing system, so the skill can generate optimized prompts specifically for MiniMax models.

### Changes

- **SKILL.md**: Added MiniMax routing section with prompt optimization guidance:
  - OpenAI-compatible API format (prompts transfer from GPT)
  - Temperature clamping (0–1 inclusive)
  - Thinking tag control (`<think>` output suppression)
  - 1M context window on M2.7, 204K on M2.5-highspeed
  - Structured output and function calling best practices
- **README.md**: Added MiniMax to the tool profiles table and "Works with" list

### Why

MiniMax M2.7 is a strong reasoning LLM with OpenAI-compatible API, 1M context window, and good instruction following. Adding it as a recognized target lets Prompt Master generate prompts tailored to MiniMax's specific strengths and constraints — temperature bounds, thinking tags, and structured output capabilities.

### No code changes

This is a documentation-only change (markdown files). No tests needed as there is no executable code in this repository.