### PR TITLE
docs: update MiniMax routing to M3 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Prompt Master includes specific profiles for 20+ tools. For anything not on the 
 | **Qwen 2.5 / Qwen3** | Open-weight LLM | Chat template format, thinking vs non-thinking mode detection |
 | **Local models (Llama, Mistral)** | Open-weight LLM | Shorter prompts, simpler structure, no complex nesting |
 | **DeepSeek-R1** | Reasoning LLM | Short clean instructions, strips CoT, suppresses thinking output if needed |
-| **MiniMax (M2.7 / M2.5)** | Reasoning LLM | Temperature clamping, thinking tag control, structured output optimization |
+| **MiniMax (M3 / M2.7)** | Reasoning LLM | Temperature clamping, thinking tag control, structured output optimization |
 | **Claude Code** | Agentic AI | Stop conditions, file scope, checkpoint output |
 | **Cursor / Windsurf** | IDE AI | File path, function name, do-not-touch list, sequential prompt guidance |
 | **Cline (formerly Claude Dev)** | Agentic IDE | File scope, approval gates, stop conditions, task breakdown |

--- a/SKILL.md
+++ b/SKILL.md
@@ -145,10 +145,10 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
-**MiniMax (M2.7 / M2.5)**
+**MiniMax (M3 / M2.7)**
 - OpenAI-compatible API — prompts that work with GPT models transfer directly
 - Strong at instruction following, structured output, and long-context synthesis — 1M context window on M2.7
-- M2.5-highspeed has a 204K context window and is optimized for speed — use for latency-sensitive tasks
+- M2.7-highspeed is optimized for speed — use for latency-sensitive tasks
 - Temperature must be between 0 and 1 (inclusive) — prompts that set temperature above 1 will fail
 - May output reasoning in `<think>` tags — add "Output only the final answer, no reasoning tags." if the user does not want visible thinking
 - Good at code generation, JSON output, and multi-step analysis — leverage these strengths


### PR DESCRIPTION
## Summary
Update the MiniMax tool routing in `SKILL.md` and the supported-tools table in `README.md` so Prompt Master references the latest M3 model alongside M2.7, and drops the deprecated M2.5 family from user-facing routing.

## Changes
- `README.md`: tool table row now reads **MiniMax (M3 / M2.7)** instead of (M2.7 / M2.5)
- `SKILL.md`: routing section header updated to **MiniMax (M3 / M2.7)**
- `SKILL.md`: replaced the M2.5-highspeed bullet with M2.7-highspeed (still the speed-optimized variant in the current line-up)
- Kept all existing routing advice (OpenAI-compatible, temperature 0–1, `<think>` tag note, function-calling guidance) unchanged — this is a model-id refresh, not a routing rewrite

## Why
M3 is MiniMax's current flagship and the model most users will be calling. Leaving the routing card pointed at M2.7 / M2.5 sends users to write prompts for a tier that is no longer the default endpoint. M2.7 (and the M2.7-highspeed variant) are still in active service, so they stay in the card; M2.5 / M2.1 / M2 / M1 are out.

## Testing
- Documentation-only diff — no runtime behavior to test
- Verified no remaining `M2.5 / M2.1 / M2 / M1` references in the repo