### PR TITLE
June 2026 model refresh (v1.7.0) + dated model fact-sheet with refresh protocol

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-master
-version: 1.6.0
+version: 1.7.0
 description: Generates optimized prompts for AI tools. Activates only when the user explicitly asks to write, fix, improve, or adapt a prompt for a specific AI tool (LLM, Cursor, Midjourney, image AI, video AI, coding agents, etc.). Does not activate for general conversation, coding tasks, document writing, or other non-prompt-engineering work.
 ---
 
@@ -24,7 +24,7 @@ Build prompts one at a time, ready to paste.
   - **Graph of Thought** -- requires an external graph engine not present in most tools
   - **Universal Self-Consistency** -- requires independent sampling passes
   - **Prompt chaining as a layered technique** -- compounds fabrication risk across longer chains
-- Do not add Chain of Thought to reasoning-native models (o3, o4-mini, DeepSeek-R1, Qwen3 thinking mode) — they think internally, CoT degrades output
+- Do not add Chain of Thought to reasoning-native models or thinking modes (GPT-5.x Thinking/Pro, DeepSeek V4 thinking, Qwen3+ thinking, Claude adaptive thinking, legacy o-series/R1) — they think internally, CoT degrades output. Full list: [references/models.md](references/models.md).
 - Do not ask more than 3 clarifying questions before producing a prompt
 - Do not pad output with explanations the user did not request
 
@@ -65,21 +65,25 @@ Before writing any prompt, silently extract these 9 dimensions. Missing critical
 
 Identify the tool and route accordingly. Read full templates from [references/templates.md](references/templates.md) only for the category you need.
 
+Model IDs, parameters, and version-tied behavior live in [references/models.md](references/models.md), each vendor section dated. If the section you need is older than 60 days (or marked UNVERIFIED), re-verify per its refresh protocol before asserting the fact — never present stale model facts as current.
+
 ---
 
-**Claude (claude.ai, Claude API, Claude 4.x)**
-- Be explicit and specific — Claude 4.x follows instructions literally. Opus 4.7 especially: it does exactly what you say, nothing more. Missing context = narrow literal output, not a smart guess.
+**Claude (claude.ai, Claude API — Fable 5, Opus 4.8/4.7, Sonnet 4.6, Haiku 4.5)**
+- Be explicit and specific — current Claude models follow instructions literally: they do exactly what you say, nothing more. Missing context = narrow literal output, not a smart guess.
 - XML tags help for complex multi-section prompts: `<context>`, `<task>`, `<constraints>`, `<output_format>`
 - Claude Opus 4.x over-engineers by default — add "Only make changes directly requested. Do not add features or refactor beyond what was asked."
 - Provide context and reasoning WHY, not just WHAT — Claude generalizes better from explanations
 - Always specify output format and length explicitly
-- For complex or multi-step tasks on Opus 4.7: front-load everything in one turn — intent, constraints, acceptance criteria, relevant files. Every extra back-and-forth turn adds reasoning overhead and token cost.
-- Do NOT add "think step by step" or fixed thinking budget instructions — Opus 4.7 uses adaptive thinking and calibrates depth automatically. To influence depth: "Think carefully before responding" (more) or "Prioritize responding quickly" (less).
-- Use Template M for agentic or multi-step tasks on Opus 4.7.
+- For complex or multi-step tasks: front-load everything in one turn — intent, constraints, acceptance criteria, relevant files. Every extra back-and-forth turn adds reasoning overhead and token cost.
+- Do NOT add "think step by step" or fixed thinking budget instructions — current Claude uses adaptive thinking and calibrates depth automatically. To influence depth: "Think carefully before responding" (more) or "Prioritize responding quickly" (less).
+- Opus 4.8 / Fable 5 behavioral shifts (narrates more, asks more often, under-reaches for tools/subagents/search) and the API param surface (adaptive-only thinking, sampling params removed, prefills removed, effort levels): see models.md → Anthropic, and apply the relevant snippets.
+- Use Template M for agentic or multi-step tasks.
 
 ---
 
 **ChatGPT / GPT-5.x / OpenAI GPT models**
+- The active lineup is all GPT-5 family — GPT-5.5 Instant (default), GPT-5.4 Thinking, GPT-5.4 Pro (see models.md → OpenAI)
 - Start with the smallest prompt that achieves the goal — add structure only when needed
 - Be explicit about the output contract: what format, what length, what "done" looks like
 - State tool-use expectations explicitly if the model has access to tools
@@ -89,7 +93,8 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
-**o3 / o4-mini / OpenAI reasoning models**
+**GPT-5.4 Thinking / Pro (OpenAI reasoning models)**
+- The o-series (o3, o4-mini) is retired — if the user names one, target GPT-5.4 Thinking and apply these same rules
 - SHORT clean instructions ONLY — these models reason across thousands of internal tokens
 - NEVER add CoT, "think step by step", or reasoning scaffolding — it actively degrades output
 - Prefer zero-shot first — add few-shot only if strictly needed and tightly aligned
@@ -98,11 +103,12 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
-**Gemini 2.x / Gemini 3 Pro**
+**Gemini (3.1 Pro current)**
 - Strong at long-context and multimodal — leverage its large context window for document-heavy prompts
+- Set `thinking_level: high` for complex reasoning tasks (API); `gemini-3-pro-preview` is discontinued — current IDs in models.md → Google
+- Tuned concise and may GUESS when information is missing — for grounded tasks always add "Base your response only on the provided context. Do not extrapolate. If information is missing, say so."
 - Prone to hallucinated citations — always add "Cite only sources you are certain of. If uncertain, say [uncertain]."
 - Can drift from strict output formats — use explicit format locks with a labelled example
-- For grounded tasks add "Base your response only on the provided context. Do not extrapolate."
 
 ---
 
@@ -114,9 +120,9 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
-**Qwen3 (thinking mode)**
+**Qwen3 / 3.5 / 3.6 (thinking mode)**
 - Two modes: thinking mode (/think or enable_thinking=True) and non-thinking mode
-- Thinking mode: treat exactly like o3 — short clean instructions, no CoT, no scaffolding
+- Thinking mode: reasoning-native — short clean instructions, no CoT, no scaffolding
 - Non-thinking mode: treat like Qwen2.5 instruct — full structure, explicit format, role assignment
 
 ---
@@ -138,10 +144,11 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
-**DeepSeek-R1**
-- Reasoning-native like o3 — do NOT add CoT instructions
-- Short clean instructions only — state the goal and desired output format
-- Outputs reasoning in `<think>` tags by default — add "Output only the final answer, no reasoning." if needed
+**DeepSeek V4 (R1 superseded)**
+- Current models: `deepseek-v4-pro` (coding/complex agents) and `deepseek-v4-flash` (fast/cheap). Legacy `deepseek-chat` / `deepseek-reasoner` names retire 2026-07-24 — never target them (models.md → DeepSeek)
+- Thinking mode is reasoning-native — do NOT add CoT instructions; short clean instructions only
+- Unlike R1, V4 supports tool calls inside thinking mode — agentic prompts no longer have to choose between reasoning and tools
+- May output reasoning in `<think>` tags — add "Output only the final answer, no reasoning." if needed
 
 ---
 
@@ -161,10 +168,10 @@ Identify the tool and route accordingly. Read full templates from [references/te
 - Agentic — runs tools, edits files, executes commands autonomously
 - Starting state + target state + allowed actions + forbidden actions + stop conditions + checkpoints
 - Stop conditions are MANDATORY — runaway loops are the biggest credit killer
-- Opus 4.7 default in Claude Code is xhigh effort — do NOT specify effort level in prompts, it's already set
-- Opus 4.7 is more literal than 4.6 — vague first turns produce narrower results. Front-load everything: intent, file scope, constraints, acceptance criteria, session strategy.
-- Opus 4.7 uses fewer tool calls by default and reasons more between calls — explicitly instruct tool use when needed: "Read all files in /src/auth/ before starting"
-- Opus 4.7 spawns fewer subagents by default — explicitly request when needed: "Use a subagent to investigate X so it stays out of main context"
+- Effort is already set (xhigh is the Claude Code default) — do NOT specify effort level in prompts
+- Current models (Fable 5, Opus 4.8/4.7) are literal — vague first turns produce narrower results. Front-load everything: intent, file scope, constraints, acceptance criteria, session strategy. For long autonomous runs, state the full goal up front.
+- Current Opus under-reaches for tools and subagents — explicitly instruct when needed: "Read all files in /src/auth/ before starting"; "Use a subagent to investigate X so it stays out of main context"
+- Opus 4.8 narrates more than 4.7 by default — remove "summarize after every N steps" scaffolding; if too chatty, add a silence-default (snippet in models.md → Anthropic)
 - Claude Opus 4.x over-engineers — add "Only make changes directly requested. Do not add extra files, abstractions, or features."
 - Always scope to specific files and directories — never give a global instruction without a path anchor
 - Human review triggers required: "Stop and ask before deleting any file, adding any dependency, or affecting the database schema"
@@ -173,7 +180,7 @@ Identify the tool and route accordingly. Read full templates from [references/te
 
 ---
 
-**Antigravity (Google's agent-first IDE, powered by Gemini 3 Pro)**
+**Antigravity (Google's agent-first IDE, powered by Gemini 3.x)**
 - Task-based prompting — describe outcomes, not steps
 - Prompt for an Artifact (task list, implementation plan) before execution so you can review it first
 - Browser automation is built-in — include verification steps: "After building, verify UI at 375px and 1440px using the browser agent"
@@ -372,8 +379,8 @@ Scan every user-provided prompt or rough idea for these failure patterns. Fix si
 - Entire codebase pasted as context → scope to the relevant file and function only
 
 **Reasoning failures**
-- Logic or analysis task with no step-by-step → add "Think through this carefully before answering"
-- CoT added to o3/o4-mini/R1/Qwen3-thinking → REMOVE IT
+- Logic or analysis task with no step-by-step → add "Think through this carefully before answering" (standard non-thinking models only)
+- CoT added to a reasoning-native model or thinking mode (models.md → Reasoning-Native List) → REMOVE IT
 - New prompt contradicts prior session decisions → flag, resolve, include memory block
 
 **Agentic failures**
@@ -410,7 +417,7 @@ When the user's request references prior work, decisions, or session history —
 **Grounding anchors** — for any factual or citation task:
 "Use only information you are highly confident is accurate. If uncertain, write [uncertain] next to the claim. Do not fabricate citations or statistics."
 
-**Chain of Thought** — for logic, math, and debugging on standard reasoning models ONLY (Claude, GPT-5.x, Gemini, Qwen2.5, Llama). Never on o3/o4-mini/R1/Qwen3-thinking.
+**Chain of Thought** — for logic, math, and debugging on standard NON-thinking models only (GPT-5.x Instant, Gemini without thinking_level, Qwen non-thinking mode, open-weight instruct models). Never on anything in the models.md Reasoning-Native List.
 "Think through this step by step before answering."
 
 ---
@@ -440,9 +447,10 @@ The user pastes the prompt into their target tool. It works on the first try. Ze
 ---
 
 ## Reference Files
-Read only when the task requires it. Do not load both at once.
+Read only when the task requires it. Do not load all at once.
 
 | File | Read When |
 |------|-----------|
+| [references/models.md](references/models.md) | Any model-specific claim — IDs, params, behavior, staleness check |
 | [references/templates.md](references/templates.md) | You need the full template structure for any tool category |
-| [references/patterns.md](references/patterns.md) | User pastes a bad prompt to fix, or you need the complete 35-pattern reference |
+| [references/patterns.md](references/patterns.md) | User pastes a bad prompt to fix, or you need the complete failure-pattern reference |

--- a/references/models.md
+++ b/references/models.md
@@ -1,0 +1,129 @@
+# Model Facts — Volatile Reference
+
+Model-specific facts (IDs, parameters, behavioral quirks) live HERE, not in SKILL.md. SKILL.md holds evergreen technique guidance; this file holds everything that rots.
+
+## Refresh Protocol
+
+Each vendor section carries a `last-verified` date and source. **Before asserting any fact from a section older than 60 days, re-verify it**:
+
+- **Anthropic / Claude** → the `claude-api` skill (authoritative, ships current model IDs and params)
+- **Libraries / dev-tool APIs** → context7
+- **Everything else** → web search: `"<vendor> current models <month> <year>"`
+
+After verifying, update the section and its `last-verified` date. Never present an expired fact as current — say "as of <date>" or verify first. Sections marked `UNVERIFIED` were carried from upstream v1.6.0 and have never been independently checked.
+
+---
+
+## Anthropic / Claude
+
+`last-verified: 2026-06-10` · source: claude-api skill (cache 2026-05-26)
+
+| Model | ID | Context | Output | Notes |
+|---|---|---|---|---|
+| Claude Fable 5 | `claude-fable-5` | 1M | 128K | Top tier, above Opus. $10/$50 per MTok |
+| Claude Opus 4.8 | `claude-opus-4-8` | 1M | 128K | Current Opus. $5/$25 |
+| Claude Opus 4.7 | `claude-opus-4-7` | 1M | 128K | Previous gen |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | 1M | 64K | Speed/intelligence balance. $3/$15 |
+| Claude Haiku 4.5 | `claude-haiku-4-5` | 200K | 64K | Fast/cheap. $1/$5 |
+
+**API params (matter when the prompt is for API/scripted use):**
+- Fable 5 / Opus 4.8 / 4.7: adaptive thinking ONLY — `thinking: {type: "adaptive"}`. `budget_tokens` returns 400. `temperature` / `top_p` / `top_k` removed (400). Fable 5 additionally 400s on explicit `thinking: {type: "disabled"}` — omit the param instead.
+- Last-assistant-turn prefills return 400 on Fable 5 and the entire 4.6+ family — use `output_config.format` (structured outputs) instead.
+- Effort levels: `low | medium | high | xhigh | max`. `xhigh` is the Claude Code default; start at `high` for API work and sweep.
+- `thinking.display` defaults to `"omitted"` on 4.7+ — reasoning text streams empty unless set to `"summarized"`.
+
+**Behavioral (Opus 4.8 / Fable 5 era — affects prompt wording):**
+- Literal instruction following: missing context = narrow output, not a smart guess. Front-load everything in one turn.
+- 4.8 **narrates more** than 4.7 (interim updates, long wrap-ups). Remove "summarize after every N steps" scaffolding; if too chatty, add a silence-default: *"Default to silence between tool calls. Only write text when you find something, change direction, or hit a blocker — one sentence each."*
+- 4.8 is **more deliberate — asks more often**. Add: *"For minor choices (naming, defaults, equivalent approaches), pick a reasonable option and note it rather than asking. For scope changes or destructive actions, still ask first."*
+- 4.8 **under-reaches for tools, subagents, search, and memory**. State trigger conditions explicitly — in the system prompt AND each tool's description: *"Call this when…"*. For research: *"For questions where current information would change the answer, search before answering rather than answering from memory."*
+- Do NOT add "think step by step" or thinking budgets — adaptive thinking calibrates itself. To influence depth: "Think carefully before responding" (more) / "Prioritize responding quickly" (less).
+- Opus 4.x over-engineers — add "Only make changes directly requested. Do not add features or refactor beyond what was asked."
+
+---
+
+## OpenAI / ChatGPT
+
+`last-verified: 2026-06-10` · source: web (openai.com release notes, TechCrunch)
+
+- **All active ChatGPT models are GPT-5 family** (consolidation 2026-02-13). The GPT-4 series and the entire o-series are retired from ChatGPT (o3 fully retires 2026-08-26; there is no o4).
+- Current lineup: **GPT-5.5 Instant** (default, released May 2026, low-latency), **GPT-5.4 Thinking** (paid reasoning), **GPT-5.4 Pro** (research-grade). GPT-5.2 and GPT-5.3-Codex are sunset.
+- If the user says "o3" / "o4-mini": route them to GPT-5.4 Thinking and apply reasoning-model rules.
+- **GPT-5.x Instant**: smallest prompt that achieves the goal; explicit output contract (format, length, "done"); dense structured instructions are fine; constrain verbosity explicitly when needed.
+- **GPT-5.x Thinking / Pro**: treat as reasoning-native — SHORT clean instructions, NO CoT or reasoning scaffolding (degrades output), zero-shot first, state what you want and what done looks like, keep system prompts lean.
+
+---
+
+## Google / Gemini
+
+`last-verified: 2026-06-10` · source: web (blog.google, ai.google.dev)
+
+- Current: **Gemini 3.1 Pro** (`gemini-3.1-pro-preview`). `gemini-3-pro-preview` was discontinued 2026-03-26 — don't target it. (Gemini 3.5 Pro rumored, not shipped as of verification.)
+- 1M context, strong multimodal (text/audio/image/video/PDF/repos) — leverage for document-heavy prompts.
+- `thinking_level` parameter controls reasoning depth (relative guideline, not token guarantee) — set "high" for complex tasks. `media_resolution` trades fine-detail reading vs token cost.
+- Tuned concise and direct; **may guess when information is missing** — for grounded tasks always add: "Base your response only on the provided context. Do not extrapolate. If information is missing, say so."
+- Still prone to hallucinated citations — add "Cite only sources you are certain of. If uncertain, say [uncertain]."
+- Can drift from strict formats — use explicit format locks with a labelled example.
+
+---
+
+## DeepSeek
+
+`last-verified: 2026-06-10` · source: web (api-docs.deepseek.com, MIT Tech Review)
+
+- Current: **DeepSeek V4** (launched 2026-04-24). `deepseek-v4-pro` = larger, coding/complex agents; `deepseek-v4-flash` = faster/cheaper.
+- **R1 is superseded** — V4's optional thinking mode covers the R1 use case. Legacy API names `deepseek-chat` and `deepseek-reasoner` are fully retired 2026-07-24; use the v4 IDs.
+- V4 thinking mode is reasoning-native: short clean instructions, no CoT. Unlike R1, **V4 supports tool calls inside thinking mode**.
+- Over OpenRouter, verify the provider route honors thinking/tool settings (some providers silently disable tools — check before relying on agentic prompts).
+
+---
+
+## Moonshot / Kimi
+
+`last-verified: 2026-06-10` · source: web (HuggingFace, moonshotai GitHub)
+
+- **Kimi K2.5** (Jan 2026): 1T-param MoE (32B active), native multimodal, strong agentic/tool use and structured output. OpenRouter ID `moonshotai/kimi-k2.5`. Responds well to explicit role assignment + clear output format specs.
+- **Kimi K2.6** (Apr 2026): open-weight 1T, ties GPT-5.5 on SWE-Bench Pro. Caveat: community-verified tool-call leak bug on sparse toolsets (hermes-agent #24534) — for tool/agent prompts on small toolsets, prefer K2.5 or re-verify before shipping.
+
+---
+
+## Alibaba / Qwen
+
+`last-verified: 2026-06-10` · source: web
+
+- **Qwen3** family (0.6B–235B MoE, 256K ctx, Apache 2.0): two modes — thinking mode = reasoning-native (short instructions, no CoT, no scaffolding); non-thinking = full structure, explicit format, role assignment.
+- **Qwen 3.5 / 3.6** are newer with stronger coding; same two-mode prompting rules apply.
+- **Qwen2.5 instruct / qwen2.5-coder** still widely deployed locally (Ollama): excellent instruction-following and JSON output; clear system-prompt role; shorter focused prompts beat long complex ones.
+
+---
+
+## MiniMax
+
+`UNVERIFIED — carried from upstream v1.6.0; re-verify before asserting`
+
+- M2.7: OpenAI-compatible API, 1M context, strong instruction following / structured output. M2.5-highspeed: 204K context, latency-optimized.
+- Temperature must be in (0, 1] — above 1 fails. May emit `<think>` tags — add "Output only the final answer, no reasoning tags." if unwanted.
+- Function calling: OpenAI-style tool definitions.
+
+---
+
+## Local / Ollama
+
+Evergreen guidance (model-dependent — ALWAYS ask which model is running):
+
+- System prompt is the highest-leverage knob — include it so the user can set it in their Modelfile.
+- Shorter, flatter prompts; local models lose coherence with deep nesting.
+- Temperature 0.1 for coding/deterministic, 0.7–0.8 creative.
+- Coding: qwen2.5-coder / a coder variant, not general-chat models.
+
+---
+
+## Image / Video / Voice / 3D Tools
+
+Version claims for these tools (Midjourney `--v`, SD checkpoints, Sora/Runway/Kling capabilities) are `UNVERIFIED — carried from upstream v1.6.0`. The technique guidance in SKILL.md is largely evergreen; verify version flags via web search before asserting them.
+
+---
+
+## Reasoning-Native List (for the hard rule)
+
+Never add CoT / "think step by step" / reasoning scaffolding to: **GPT-5.4 Thinking & Pro · DeepSeek V4 thinking mode · Qwen3+ thinking mode · Claude adaptive thinking (4.6+/Fable) · legacy o-series & R1** (retired, but users may still target them). They reason internally; CoT degrades output.

--- a/references/patterns.md
+++ b/references/patterns.md
@@ -1,6 +1,6 @@
 # Credit-Killing Patterns Reference
 
-37 patterns that waste tokens and cause re-prompts. Read this file when the user pastes a bad prompt and asks you to fix it, or when diagnosing why a prompt is underperforming.
+38 patterns that waste tokens and cause re-prompts. Read this file when the user pastes a bad prompt and asks you to fix it, or when diagnosing why a prompt is underperforming.
 
 ---
 
@@ -62,7 +62,7 @@
 | # | Pattern | Bad Example | Fixed |
 |---|---------|------------|-------|
 | 26 | **No CoT for logic task** | "which approach is better?" | "Think through both approaches step by step before recommending" |
-| 27 | **Adding CoT to reasoning models** | "think step by step" sent to o1/o3 | Remove it — reasoning models think internally, CoT instructions degrade output |
+| 27 | **Adding CoT to reasoning models** | "think step by step" sent to GPT-5.x Thinking, DeepSeek V4 thinking, Qwen3+ thinking, or Claude adaptive thinking | Remove it — reasoning-native models think internally, CoT instructions degrade output (full list: models.md) |
 | 28 | **Expecting inter-session memory** | "you already know my project" | Always re-provide the Memory Block in every new session |
 | 29 | **Contradicting prior work** | New prompt ignores earlier architecture | Include Memory Block with all established decisions |
 | 30 | **No grounding rule for factual tasks** | "summarize what experts say about X" | "Use only information you are highly confident is accurate. Say [uncertain] if not." |
@@ -78,5 +78,6 @@
 | 33 | **Silent agent** | No progress output | "After each step output: ✅ [what was completed]" |
 | 34 | **Unlocked filesystem** | No file restrictions | "Only edit files inside `src/`. Do not touch `package.json`, `.env`, or any config file." |
 | 35 | **No human review trigger** | Agent decides everything autonomously | "Stop and ask before: deleting any file, adding any dependency, or changing the database schema" |
-| 36 | **Vague first turn on Opus 4.7** | "fix the auth bug" with no scope, no files, no criteria | Opus 4.7 reads prompts literally — it no longer fills implicit context like 4.6 did. Use Template M. Front-load intent, file scope, constraints, and acceptance criteria. |
-| 37 | **Context rot on long sessions** | Keeps correcting in the same session for 60+ turns | New task = new session. Use /rewind instead of correcting. /compact at ~50% context. Subagents for file-heavy investigation. |schema" |
+| 36 | **Vague first turn on current Claude** | "fix the auth bug" with no scope, no files, no criteria | Fable 5 / Opus 4.8 / 4.7 read prompts literally — they do not fill implicit context like older models did. Use Template M. Front-load intent, file scope, constraints, and acceptance criteria. |
+| 37 | **Context rot on long sessions** | Keeps correcting in the same session for 60+ turns | New task = new session. Use /rewind instead of correcting. /compact at ~50% context. Subagents for file-heavy investigation. |
+| 38 | **Hardcoded retired model or dead parameter** | Prompt targets o3 / deepseek-reasoner, or sets `temperature` / `budget_tokens` for Opus 4.7+ | Replace with the current equivalent per models.md, and tell the user what changed and why |

--- a/references/templates.md
+++ b/references/templates.md
@@ -18,7 +18,7 @@ Full template library for Prompt Master. Read the relevant template when the use
 | [J — Reference Image Editing](#template-j--reference-image-editing) | Editing an existing image with a reference |
 | [K — ComfyUI](#template-k--comfyui) | ComfyUI node-based image workflows |
 | [L — Prompt Decompiler](#template-l--prompt-decompiler) | Breaking down, adapting, or splitting existing prompts |
-| [M — Opus 4.7 Task Brief](#template-m--opus-4.7-task-brief) | Complex, multi-step, or agentic task on Claude Opus 4.7 |
+| [M — Claude Agentic Task Brief](#template-m--claude-agentic-task-brief) | Complex, multi-step, or agentic task on current Claude (Fable 5, Opus 4.8/4.7) |
 
 ---
 
@@ -125,7 +125,7 @@ Experiment: Give 3 variants ranging from minimal to bold.
 
 *Use for logic-heavy tasks, math, debugging, and multi-factor analysis where the AI needs to reason carefully before committing to an answer.*
 
-**Important:** Only use CoT for standard reasoning models (Claude, GPT-4o, Gemini). Do NOT add CoT instructions to o1, o3, or Claude extended thinking — they reason internally and CoT instructions degrade their output.
+**Important:** Only use CoT for standard NON-thinking models (GPT-5.x Instant, Gemini without thinking_level, open-weight instruct models). Do NOT add CoT to reasoning-native models or thinking modes — GPT-5.x Thinking/Pro, DeepSeek V4 thinking, Qwen3+ thinking, Claude adaptive thinking, legacy o-series/R1 — they reason internally and CoT instructions degrade their output. Full list: models.md → Reasoning-Native List.
 
 ```
 [Task statement]
@@ -148,7 +148,7 @@ Give your final answer in <answer> tags only.
 - Analysis where a wrong first impression is likely
 
 **When NOT to use:**
-- o1 / o3 / reasoning models (they think internally — adding CoT hurts)
+- Reasoning-native models / thinking modes (they think internally — adding CoT hurts)
 - Simple tasks where the answer is clear (unnecessary overhead)
 - Creative tasks (CoT can kill natural voice)
 
@@ -396,9 +396,9 @@ Run these in order. Each output feeds the next.
 ```
 ---
 
-## Template M — Opus 4.7 Task Brief
+## Template M — Claude Agentic Task Brief
 
-*Use for any complex, multi-step, or agentic task on Claude Opus 4.7 — claude.ai, API, or Claude Code. Opus 4.7 reads prompts literally. Missing context produces narrow output. This template front-loads everything so the first turn is the only turn.*
+*Use for any complex, multi-step, or agentic task on current Claude models (Fable 5, Opus 4.8, Opus 4.7) — claude.ai, API, or Claude Code. These models read prompts literally: missing context produces narrow output, not a smart guess. This template front-loads everything so the first turn is the only turn — which is also how current Opus performs best on long autonomous runs.*
 
 ```
 ## Objective
@@ -449,4 +449,7 @@ After each completed step: ✅ [what was done] — [file(s) affected]
 - Compact first — run /compact [focus on X] then begin
 ```
 
-**When to use:** Opus 4.7 on any surface — claude.ai, API, Claude Code — when the task is complex, multi-file, ambiguous, or agentic. Not needed for simple one-shot tasks.
+**Autonomy calibration (Opus 4.8 / Fable 5)** — current Opus asks more often on minor decisions. If the task should run unattended, add:
+`"For minor choices (naming, formatting, default values, equivalent approaches), pick a reasonable option and note it rather than asking. For scope changes or destructive actions, still ask first."`
+
+**When to use:** Current Claude on any surface — claude.ai, API, Claude Code — when the task is complex, multi-file, ambiguous, or agentic. Not needed for simple one-shot tasks.


### PR DESCRIPTION
## What

Model-fact refresh verified against current vendor docs (2026-06-10), plus a structural fix so the skill stops going stale silently.

### New: `references/models.md`
All volatile model facts (IDs, params, version-tied behavior) move into one fact-sheet. Each vendor section carries a `last-verified` date, and the skill is instructed to **re-verify any section older than 60 days before asserting it**. This addresses the root cause of staleness — facts hardcoded in evergreen instruction text — rather than just this round's symptoms.

### Fact updates (all verified 2026-06-10)
- **Claude**: updated from the Opus 4.7 framing to the Fable 5 / Opus 4.8 era — adaptive-only thinking (`budget_tokens`/sampling params/prefills 400 on 4.7+), effort levels incl. `xhigh`, and Opus 4.8's behavioral shifts (narrates *more* than 4.7, asks more often, conservative tool/subagent triggering) with corrective prompt snippets. The old "silent agent → add progress output" advice now backfires on 4.8.
- **OpenAI**: the o3/o4-mini section described retired models — ChatGPT consolidated to all-GPT-5 in Feb 2026. Section replaced with GPT-5.4 Thinking/Pro carrying the same reasoning-model rules; GPT-5.5 Instant noted as the default.
- **Gemini**: current model is 3.1 Pro (`gemini-3-pro-preview` discontinued 2026-03-26); added `thinking_level` and the documented may-guess-when-info-missing caveat.
- **DeepSeek**: R1 section replaced by V4 (Pro/Flash, launched 2026-04-24); legacy `deepseek-chat`/`deepseek-reasoner` names retire 2026-07-24; V4 supports tool calls inside thinking mode.
- **Kimi K2.5/K2.6** and **Qwen 3.5/3.6** added to the fact-sheet.

### Template/pattern fixes
- Template M generalized from "Opus 4.7 Task Brief" to a current-Claude agentic brief (+ autonomy-calibration snippet for 4.8's higher ask-rate).
- Template E and pattern #27 CoT exclusion lists updated to reasoning-native *modes* rather than retired model names.
- New pattern #38: prompt hardcodes a retired model or dead parameter.
- Fixed the corrupted table row at the end of patterns.md (stray `schema\" |`).

## Why the split matters
v1.6.0's facts were correct at commit time and wrong within a quarter — same will happen to this PR's facts. The dated fact-sheet + refresh protocol makes the skill degrade gracefully (re-verify) instead of confidently asserting last quarter's model landscape.

Happy to split this into smaller PRs if preferred.