### PR TITLE
feat: make prompt-master installable as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,10 +7,7 @@
   "plugins": [
     {
       "name": "prompt-master",
-      "source": {
-        "type": "relative",
-        "path": "."
-      },
+      "source": ".",
       "version": "1.7.0",
       "description": "Generates optimized, token-efficient prompts for any AI tool."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "prompt-master",
+  "owner": {
+    "name": "nidhinjs",
+    "url": "https://github.com/nidhinjs"
+  },
+  "plugins": [
+    {
+      "name": "prompt-master",
+      "source": {
+        "type": "relative",
+        "path": "."
+      },
+      "version": "1.7.0",
+      "description": "Generates optimized, token-efficient prompts for any AI tool."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prompt-master",
+  "version": "1.7.0",
+  "description": "Generates optimized, token-efficient prompts for any AI tool. Activates only when explicitly asked to write, fix, improve, or adapt a prompt for a specific AI tool.",
+  "author": {
+    "name": "nidhinjs",
+    "url": "https://github.com/nidhinjs"
+  },
+  "homepage": "https://github.com/nidhinjs/prompt-master",
+  "repository": "https://github.com/nidhinjs/prompt-master",
+  "license": "MIT",
+  "keywords": [
+    "prompt-engineering",
+    "prompts",
+    "claude-skill",
+    "ai-tools"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ A Claude skill that writes the accurate prompts for any AI tool. Zero tokens or 
 2. Go to **claude.ai → Sidebar → Customize → Skills → Upload a Skill**
 
 
+### RECOMMENDED - Claude Code (plugin)
+
+Install as a Claude Code plugin straight from this repo — it doubles as its own marketplace:
+
+```bash
+/plugin marketplace add nidhinjs/prompt-master
+/plugin install prompt-master@prompt-master
+```
+
+Updating later is one command:
+
+```bash
+/plugin marketplace update prompt-master
+```
+
 ### OR Clone directly into Claude Code skills directory (Not Suggested)
 
 ```bash


### PR DESCRIPTION
## Summary

Packages the existing prompt-master skill so it can be installed as a **Claude Code plugin** straight from this repo — the repo now doubles as its own marketplace.

- `.claude-plugin/plugin.json` — plugin manifest (single-skill plugin, root `SKILL.md`, v1.7.0, MIT, authored to nidhinjs).
- `.claude-plugin/marketplace.json` — marketplace manifest with one plugin sourced at the repo root (`type: relative, path: .`).
- `README.md` — adds a "Claude Code (plugin)" install section.

Install becomes:

```
/plugin marketplace add nidhinjs/prompt-master
/plugin install prompt-master@prompt-master
```

## Context

No changes to the skill itself — `SKILL.md` and `references/` are untouched, so the existing claude.ai upload and manual clone-into-`~/.claude/skills` paths keep working exactly as before. This is purely additive: it gives teams a one-command install and a marketplace they can wire into a project's `.claude/settings.json` for automatic, team-wide enablement.