### PR TITLE
fix: use string source path in marketplace.json for Claude Code 2.1.178 compat

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,10 +7,7 @@
   "plugins": [
     {
       "name": "prompt-master",
-      "source": {
-        "type": "relative",
-        "path": "."
-      },
+      "source": ".",
       "version": "1.7.0",
       "description": "Generates optimized, token-efficient prompts for any AI tool."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "prompt-master",
+  "owner": {
+    "name": "nidhinjs",
+    "url": "https://github.com/nidhinjs"
+  },
+  "plugins": [
+    {
+      "name": "prompt-master",
+      "source": {
+        "type": "relative",
+        "path": "."
+      },
+      "version": "1.7.0",
+      "description": "Generates optimized, token-efficient prompts for any AI tool."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prompt-master",
+  "version": "1.7.0",
+  "description": "Generates optimized, token-efficient prompts for any AI tool. Activates only when explicitly asked to write, fix, improve, or adapt a prompt for a specific AI tool.",
+  "author": {
+    "name": "nidhinjs",
+    "url": "https://github.com/nidhinjs"
+  },
+  "homepage": "https://github.com/nidhinjs/prompt-master",
+  "repository": "https://github.com/nidhinjs/prompt-master",
+  "license": "MIT",
+  "keywords": [
+    "prompt-engineering",
+    "prompts",
+    "claude-skill",
+    "ai-tools"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ A Claude skill that writes the accurate prompts for any AI tool. Zero tokens or 
 2. Go to **claude.ai → Sidebar → Customize → Skills → Upload a Skill**
 
 
+### RECOMMENDED - Claude Code (plugin)
+
+Install as a Claude Code plugin straight from this repo — it doubles as its own marketplace:
+
+```bash
+/plugin marketplace add nidhinjs/prompt-master
+/plugin install prompt-master@prompt-master
+```
+
+Updating later is one command:
+
+```bash
+/plugin marketplace update prompt-master
+```
+
 ### OR Clone directly into Claude Code skills directory (Not Suggested)
 
 ```bash


### PR DESCRIPTION
## Summary
- `{"type": "relative", "path": "."}` object form throws "source type not supported" in Claude Code 2.1.178
- Warp plugin (working reference) uses simple string form `"./plugins/warp"`
- Changed to `"."` — same semantics, compatible format

## Context
Claude Code 2.1.178 (current latest) does not support the object-style `source` in marketplace.json. String path is the supported form.