### PR TITLE
feat: refresh Claude OpenAI and Grok routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Claude skill that writes the accurate prompts for any AI tool. Zero tokens or credits wasted. Full context and memory retention. No re-prompting your way to an answer you should have gotten on attempt one.
 
-**Works with:** Claude, ChatGPT, Gemini, o1/o3, MiniMax, Cursor, Claude Code, GitHub Copilot, Windsurf, Bolt, v0, Lovable, Devin, Perplexity, Midjourney, DALL-E, Stable Diffusion, ComfyUI, Sora, Runway, ElevenLabs, Zapier, Make, and any AI tool you throw at it.
+**Works with:** Claude, ChatGPT, Codex, Grok, Gemini, o1/o3, MiniMax, Cursor, Claude Code, GitHub Copilot, Windsurf, Bolt, v0, Lovable, Devin, Perplexity, Midjourney, DALL-E, Stable Diffusion, ComfyUI, Sora, Runway, ElevenLabs, Zapier, Make, and any AI tool you throw at it.
 
 ---
 
@@ -86,8 +86,9 @@ Prompt Master runs a structured pipeline on every request:
 3. **Asks targeted clarifying questions** — max 3 questions if critical info is missing, never more
 4. **Routes to the right framework** — picks and applies the correct prompt architecture automatically, never shown to the user
 5. **Applies safe techniques only** — role assignment, few-shot examples, XML structure, grounding anchors, memory block as needed
-6. **Runs a token efficiency audit** — strips every word that doesn't change the output
-7. **Delivers the prompt** — one clean copyable block with a one-line strategy note
+6. **Checks model recency** — verifies exact models and controls against official provider docs when the request depends on "latest"
+7. **Runs a token efficiency audit** — strips every word that doesn't change the output
+8. **Delivers the prompt** — one clean copyable block with a one-line strategy note
 
 ---
 ## Full Example #1: Generating Prompts for Images
@@ -200,8 +201,10 @@ Prompt Master includes specific profiles for 20+ tools. For anything not on the 
 
 | Tool | Category | What Prompt Master Fixes |
 |------|----------|--------------------------|
-| **Claude** | Reasoning LLM | Removes padding, adds XML structure, specifies length |
-| **ChatGPT / GPT-5.x** | Reasoning LLM | Output contract, verbosity control, completion criteria |
+| **Claude 5 / current Claude** | Reasoning and agentic LLM | Model-aware effort, scope, XML structure, and delegation control |
+| **ChatGPT / GPT-5.6** | Reasoning and agentic LLM | Sol/Terra/Luna routing, lean contracts, autonomy and effort control |
+| **Codex** | Coding agent | File scope, approval boundaries, verification, bounded subagents |
+| **Grok 4.6** | Reasoning and agentic LLM | Search grounding, reasoning effort, tools, caching, and stop conditions |
 | **Gemini 2.x** | Reasoning LLM | Grounding anchors, citation rules, format locks |
 | **o3 / o4-mini** | Thinking LLM | Short clean instructions only — never adds CoT (they think internally) |
 | **Ollama** | Local LLM | Asks which model is loaded, includes system prompt for Modelfile |
@@ -240,12 +243,12 @@ Prompt Master includes specific profiles for 20+ tools. For anything not on the 
 
 ---
 
-## 📐 12 Prompt Templates (Auto-Selected)
+## 📐 13 Prompt Templates (Auto-Selected)
 
 Prompt Master picks the right architecture for every task automatically and routes silently — you never see the framework name, just the prompt.
 
 <details>
-<summary><h3> Click to view all 12 templates</h3></summary>
+<summary><h3> Click to view all 13 templates</h3></summary>
 
 | Template | Best For |
 |----------|----------|
@@ -253,7 +256,7 @@ Prompt Master picks the right architecture for every task automatically and rout
 | **CO-STAR** (Context, Objective, Style, Tone, Audience, Response) | Professional documents, reports, business writing |
 | **RISEN** (Role, Instructions, Steps, End Goal, Narrowing) | Complex multi-step projects |
 | **CRISPE** (Capacity, Role, Insight, Statement, Personality, Experiment) | Creative work, brand voice, iterative content |
-| **Chain of Thought** | Math, logic, debugging, multi-step analysis |
+| **Auditable Reasoning** | Checkable math, logic, debugging, and analysis without hidden reasoning requests |
 | **Few-Shot** | Consistent structured output, pattern replication |
 | **File-Scope Template** | Cursor, Windsurf, Copilot — any code editing AI |
 | **ReAct + Stop Conditions** | Claude Code, Devin, AutoGPT — any autonomous agent |
@@ -261,6 +264,7 @@ Prompt Master picks the right architecture for every task automatically and rout
 | **Reference Image Editing** | Editing an existing image — detects edit vs generate automatically |
 | **ComfyUI** | Node-based image workflows — positive/negative split per checkpoint |
 | **Prompt Decompiler** | Breaking down, adapting, simplifying, or splitting existing prompts |
+| **Current Claude Task Brief** | Complex, multi-step, or agentic tasks on current Claude models |
 
 </details>
 
@@ -276,11 +280,11 @@ Prompt Master only uses techniques with reliable, bounded effects. Methods known
 | **Few-Shot Examples** | Adds 2-5 examples when format consistency matters more than instructions |
 | **XML Structural Tags** | Wraps sections in XML for Claude-based tools that parse it reliably |
 | **Grounding Anchors** | Adds anti-hallucination rules for factual and citation tasks |
-| **Chain of Thought** | Forces step-by-step reasoning for logic tasks — never applied to o1/o3 |
+| **Auditable Reasoning** | Requests conclusions, assumptions, evidence, and verification without hidden reasoning |
 
 ---
 
-## 🚫 35 Credit-Killing Patterns Detected (with Before/After Examples)
+## 🚫 37 Credit-Killing Patterns Detected (with Before/After Examples)
 
 <details>
 <summary><h3> Task Patterns (7)</h3></summary>
@@ -349,16 +353,16 @@ Prompt Master only uses techniques with reliable, bounded effects. Methods known
 
 | # | Pattern | Before | After |
 |---|---------|--------|-------|
-| 26 | **No CoT for logic task** | "which approach is better?" | "Think through both approaches step by step before recommending" |
-| 27 | **Adding CoT to reasoning models** | "think step by step" sent to o1/o3 | Removed, reasoning models think internally and CoT instructions degrade output |
-| 28 | **No self-check on complex output** | (nothing) | "Before finishing, verify output against the constraints above" |
-| 29 | **Expecting inter-session memory** | "you already know my project" | Always re-provide the Memory Block |
-| 30 | **Contradicting prior decisions** | New prompt ignores earlier architecture | Memory Block with all established facts |
+| 26 | **No audit contract for logic task** | "which approach is better?" | Request the recommendation, assumptions, criteria, evidence, and checks |
+| 27 | **Requesting hidden reasoning** | "show your chain of thought" | Ask for a concise rationale, evidence, and verification instead |
+| 28 | **Expecting inter-session memory** | "you already know my project" | Re-provide the Memory Block in every new session |
+| 29 | **Contradicting prior work** | New prompt ignores earlier architecture | Include established decisions in the Memory Block |
+| 30 | **No grounding rule for factual tasks** | "summarize what experts say about X" | Require verifiable sources and explicit uncertainty |
 
 </details>
 
 <details>
-<summary><h3> Agentic Patterns (5)</h3></summary>
+<summary><h3> Agentic Patterns (7)</h3></summary>
 
 | # | Pattern | Before | After |
 |---|---------|--------|-------|
@@ -367,6 +371,8 @@ Prompt Master only uses techniques with reliable, bounded effects. Methods known
 | 33 | **Silent agent** | No progress output | "After each step output: ✅ [what was completed]" |
 | 34 | **Unlocked filesystem** | No file restrictions | "Only edit files inside `src/`. Do not touch `package.json`, `.env`, or any config file." |
 | 35 | **No human review trigger** | Agent decides everything | "Stop and ask before: deleting any file, adding any dependency, or touching the database schema" |
+| 36 | **Vague first turn for an agentic model** | "fix the auth bug" with no scope, files, or criteria | Front-load outcome, context, scope, boundaries, and acceptance criteria |
+| 37 | **Context rot on long sessions** | Repeated corrections leave stale assumptions in context | Start fresh for unrelated work or compact around current decisions and state |
 
 </details>
 
@@ -391,6 +397,7 @@ This is the single biggest fix for long sessions. Most wasted re-prompts come fr
 
 ## ℹ️ Version History
 
+- **1.8.0** — Current-model refresh. Added Claude Fable 5, Opus 5, Sonnet 5, GPT-5.6 Sol/Terra/Luna, Codex, and Grok 4.6 routing. Replaced hidden chain-of-thought requests with auditable reasoning and generalized the Claude task brief for current adaptive-thinking models.
 - **1.7.0** — Opus 4.8 compatibility. Made Claude 4.x routing version-aware: durable advice generalized across 4.6/4.7/4.8, added Opus 4.8 (current default) profile, kept Opus 4.7 labeled. De-hardcoded the effort-level note (now harness-managed). Template M and pattern 36 cover 4.7 and 4.8. Fixed a stray fragment in patterns.md.
 - **1.6.0** — Opus 4.7 update. Added Template M (Opus 4.7 Task Brief). Updated Claude and Claude Code routing for literalism, adaptive thinking, xhigh effort, and session hygiene. Added patterns 36–37.
 - **1.5.0** — Added more tool routing. New Agentic AI and 3D Model AI routing added. Fixed description to 189 chars. Removed token estimate from output. Added instruction layer and copywriting placeholders

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-master
-version: 1.7.0
+version: 1.8.0
 description: Generates optimized prompts for AI tools. Activates only when the user explicitly asks to write, fix, improve, or adapt a prompt for a specific AI tool (LLM, Cursor, Midjourney, image AI, video AI, coding agents, etc.). Does not activate for general conversation, coding tasks, document writing, or other non-prompt-engineering work.
 ---
 
@@ -18,13 +18,13 @@ Build prompts one at a time, ready to paste.
 **Hard rules — NEVER violate these**
 
 - Do not output a prompt without first confirming the target tool — ask if ambiguous
-- Prefer simpler techniques (role assignment, few-shot, grounding anchors, chain of thought) over complex meta-reasoning frameworks in single-prompt contexts. The following techniques carry higher fabrication risk when used in a single prompt and should only be applied when the user explicitly requests them and the target tool supports them:
+- Prefer simpler techniques (role assignment, few-shot examples, grounding anchors, and explicit verification criteria) over complex meta-reasoning frameworks in single-prompt contexts. The following techniques carry higher fabrication risk when used in a single prompt and should only be applied when the user explicitly requests them and the target tool supports them:
   - **Mixture of Experts** -- simulated multi-persona routing in a single forward pass
   - **Tree of Thought** -- simulated branching without real parallel execution
   - **Graph of Thought** -- requires an external graph engine not present in most tools
   - **Universal Self-Consistency** -- requires independent sampling passes
   - **Prompt chaining as a layered technique** -- compounds fabrication risk across longer chains
-- Do not add Chain of Thought to reasoning-native models (o3, o4-mini, DeepSeek-R1, Qwen3 thinking mode) — they think internally, CoT degrades output
+- Never request hidden chain-of-thought, private reasoning, or a verbatim reasoning trace from any model. Ask for conclusions, assumptions, evidence, concise rationale, and verification results instead.
 - Do not ask more than 3 clarifying questions before producing a prompt
 - Do not pad output with explanations the user did not request
 
@@ -65,39 +65,58 @@ Before writing any prompt, silently extract these 9 dimensions. Missing critical
 
 Identify the tool and route accordingly. Read full templates from [references/templates.md](references/templates.md) only for the category you need.
 
----
+### Model Recency Gate
 
-**Claude (claude.ai, Claude API, Claude 4.x)**
+Model names, defaults, controls, and availability change quickly. When the user asks for the "latest" model, names a model not covered below, or needs exact API settings:
 
-Current default is **Opus 4.8**. Opus 4.7 is still selectable — keep its notes, but assume 4.8 unless the user names a specific version.
-
-*Durable across Claude 4.x (4.6 / 4.7 / 4.8):*
-- Be explicit and specific — Claude 4.x follows instructions literally. It does exactly what you say, nothing more. Missing context = narrow literal output, not a smart guess.
-- Claude Opus 4.x over-engineers by default — add "Only make changes directly requested. Do not add features or refactor beyond what was asked."
-- XML tags help for complex multi-section prompts: `<context>`, `<task>`, `<constraints>`, `<output_format>`
-- Provide context and reasoning WHY, not just WHAT — Claude generalizes better from explanations
-- Always specify output format and length explicitly
-- For complex or multi-step tasks: front-load everything in one turn — intent, constraints, acceptance criteria, relevant files. Every extra back-and-forth turn adds reasoning overhead and token cost.
-- Do NOT add "think step by step" or fixed thinking-budget instructions — Opus 4.x uses adaptive thinking and calibrates depth automatically. To influence depth: "Think carefully before responding" (more) or "Prioritize responding quickly" (less).
-- Use Template M for agentic or multi-step tasks.
-
-*Opus 4.8 (current default):*
-- Shares 4.7's literalism and adaptive thinking — the same front-loading discipline applies. Treat the first turn as the only turn for complex work: intent, scope, constraints, acceptance criteria up front.
-- 1M-token context window — large multi-file context can go in a single prompt, but keep it relevant; padding still dilutes attention.
-- Effort/thinking depth is calibrated automatically — do not specify an effort level or thinking budget.
-
-*Opus 4.7 (still selectable):*
-- More literal than 4.6 — vague first turns produce narrower results. Front-load intent, file scope, constraints, and acceptance criteria.
+1. Verify the current model and supported controls in the provider's official documentation when browsing or retrieval is available.
+2. Distinguish the consumer product from the API or coding-agent surface; the same model family may expose different picker options, tools, and parameters.
+3. Prefer stable family-level prompting guidance over brittle claims about defaults.
+4. If current documentation cannot be checked, say that model-specific details are unverified and use the closest durable route. Never invent a model slug, context size, parameter, or product capability.
 
 ---
 
-**ChatGPT / GPT-5.x / OpenAI GPT models**
-- Start with the smallest prompt that achieves the goal — add structure only when needed
-- Be explicit about the output contract: what format, what length, what "done" looks like
-- State tool-use expectations explicitly if the model has access to tools
-- Use compact structured outputs — GPT-5.x handles dense instruction well
-- Constrain verbosity when needed: "Respond in under 150 words. No preamble. No caveats."
-- GPT-5.x is strong at long-context synthesis and tone adherence — leverage these
+**Claude (claude.ai, Claude API, Claude 5 / current Claude models)**
+
+Do not assume one universal Claude default. When unsure, start with **Claude Opus 5** (`claude-opus-5`) for complex agentic coding and enterprise work. Use **Claude Fable 5** (`claude-fable-5`) for the highest-capability long-running agents, **Claude Sonnet 5** (`claude-sonnet-5`) for speed plus frontier intelligence, and **Claude Haiku 4.5** for fast, economical workloads. Ask which model only when the distinction changes the prompt.
+
+*Durable across current Claude models:*
+- Be clear and direct. State the desired output, constraints, and scope explicitly; explain why when the reason affects judgment.
+- Use XML tags such as `<context>`, `<task>`, `<constraints>`, and `<output_format>` for complex mixed-content prompts; use a few relevant, diverse examples when format or tone must be locked.
+- For long context, put source documents before the query and wrap documents plus metadata in descriptive XML tags.
+- Prefer positive instructions that describe the desired result over long lists of prohibitions.
+- Do not request hidden reasoning or reproduce thinking. Ask for a concise rationale, evidence, and verification results.
+- Current Claude 5 models use adaptive thinking and an effort control. Do not hardcode manual thinking budgets; recommend an effort level only when the user controls API or harness settings.
+- Use Template M for complex or agentic tasks.
+
+*Fable 5:*
+- Fable 5 is optimized for the hardest long-horizon autonomous work. Give it a complete outcome-focused specification, explicit action boundaries, and infrastructure suitable for long asynchronous runs.
+- Ground every long-run progress claim in actual tool results. Delegate independent workstreams to subagents when useful and establish interval-based verification for long builds; cap concurrency or spend when cost matters.
+
+*Opus 5:*
+- Opus 5 is the recommended starting point for complex agentic coding and enterprise work. Keep scope tight: "Deliver what was asked. Do not add features, refactors, or abstractions beyond the task."
+- Opus 5 already self-verifies strongly. Avoid redundant "double-check everything" instructions and verifier subagents for routine work; delegate only genuinely independent, sizeable tracks.
+
+*Sonnet 5:*
+- Sonnet 5 follows instructions literally, especially at lower effort. State when a rule applies to every item or section.
+- Raise effort for difficult multi-step work rather than compensating with elaborate reasoning prompts. Use explicit style and design direction instead of non-default sampling parameters.
+
+*Claude 4.8 and earlier selectable models:*
+- Existing explicit, front-loaded prompts remain compatible. If the model is 4.7 or later, use adaptive thinking and effort rather than `budget_tokens`.
+
+---
+
+**ChatGPT / GPT-5.6 / OpenAI GPT models**
+- Current GPT-5.6 family: **Sol** (`gpt-5.6-sol`, also the `gpt-5.6` alias) for flagship capability, **Terra** (`gpt-5.6-terra`) for balanced everyday work, and **Luna** (`gpt-5.6-luna`) for fast, repeatable, high-volume work. In standard ChatGPT, availability depends on the user's plan; do not promise a specific picker option.
+- Start lean. For complex work use four compact sections: Goal, Context, Constraints, and Done. State each instruction once.
+- GPT-5.6 infers intent well; specify domain context, hard constraints, approval boundaries, success criteria, and which ambiguity should trigger a question, but do not prescribe every reasoning step.
+- Define autonomy clearly: safe in-scope local inspection, edits, and validation may proceed; external writes, destructive actions, purchases, and material scope expansion require confirmation.
+- Use the lowest reasoning effort that meets the quality bar.
+- For the API, recommend higher effort, `reasoning.mode: "pro"`, or Responses multi-agent beta only when measured quality justifies the added latency and cost. Pro mode is not a separate API model slug.
+- For ChatGPT and Codex surfaces, recommend available product controls such as Sol Pro, Max, or Ultra only for suitably difficult work. Do not translate those UI controls into API parameters.
+- State tool-use expectations and required evidence explicitly. Use programmatic or multi-agent tool orchestration only for bounded work that divides cleanly.
+- Never request hidden reasoning. Ask for conclusions, assumptions, evidence, and checks.
+- Control visible length with the output contract (and `text.verbosity` in the API), not by asking for less thinking.
 
 ---
 
@@ -107,6 +126,17 @@ Current default is **Opus 4.8**. Opus 4.7 is still selectable — keep its notes
 - Prefer zero-shot first — add few-shot only if strictly needed and tightly aligned
 - State what you want and what done looks like. Nothing more.
 - Keep system prompts under 200 words — longer prompts hurt performance on reasoning models
+
+---
+
+**Grok / Grok 4.6 / xAI**
+- Use `grok-4.6` for current general chat, coding, agentic, and knowledge-work prompts. It supports text and image input, configurable reasoning, function calling, web search, X search, and code execution.
+- Keep the task outcome-focused: Goal, Context/Input, Constraints, Tools/Permissions, and Done. Grok 4.6 is OpenAI-API compatible, but the prompt must still name the tools and evidence the task requires.
+- Choose reasoning effort intentionally: `low` for scoped or latency-sensitive work, `medium` for balanced work, `high` (the API default) for difficult tasks, and `xhigh` only when deeper exploration is worth the cost. Grok 4.6 reasoning cannot be disabled. Do not ask for chain-of-thought.
+- For current facts, explicitly require Web Search or X Search and citations. Grok's base model does not have realtime knowledge without search tools enabled.
+- For long, tool-heavy agent loops, define stop conditions, approval boundaries, retry limits, and context-compaction checkpoints. Keep stable instructions at the front to preserve prompt-cache reuse.
+- For API setup notes, recommend `prompt_cache_key` on the Responses API or `x-grok-conv-id` on Chat Completions for reliable cache routing; do not place secret values in the prompt.
+- Consumer Grok and the xAI API expose different controls. If the user is in grok.com or X and cannot set model parameters, encode only behavioral requirements in the prompt rather than API settings.
 
 ---
 
@@ -173,15 +203,22 @@ Current default is **Opus 4.8**. Opus 4.7 is still selectable — keep its notes
 - Agentic — runs tools, edits files, executes commands autonomously
 - Starting state + target state + allowed actions + forbidden actions + stop conditions + checkpoints
 - Stop conditions are MANDATORY — runaway loops are the biggest credit killer
-- Default model is Opus 4.8 (4.7 still selectable). Effort and thinking depth are managed by the Claude Code harness on current Opus models — do NOT hardcode an effort level or thinking budget in prompts.
-- Opus 4.7 and 4.8 are more literal than 4.6 — vague first turns produce narrower results. Front-load everything: intent, file scope, constraints, acceptance criteria, session strategy.
-- Opus 4.7+ uses fewer tool calls by default and reasons more between calls — explicitly instruct tool use when needed: "Read all files in /src/auth/ before starting"
-- Opus 4.7+ spawns fewer subagents by default — explicitly request when needed: "Use a subagent to investigate X so it stays out of main context"
-- Claude Opus 4.x over-engineers — add "Only make changes directly requested. Do not add extra files, abstractions, or features."
+- Do not assume the Claude Code model. Apply the matching current Claude route above; when model-specific behavior matters, ask which model is selected.
+- Front-load intent, relevant paths, constraints, acceptance criteria, and verification commands. Explicitly request tool use when inspection is required.
+- Current Fable/Opus models can over-scope and delegate readily. Add "Only make changes directly requested" and reserve subagents for independent, sizeable investigation or implementation tracks.
+- Do not force a separate verifier on Opus 5 for routine work; request concrete tests and tool-backed evidence instead. For long Fable 5 runs, require progress claims to cite actual tool results.
 - Always scope to specific files and directories — never give a global instruction without a path anchor
 - Human review triggers required: "Stop and ask before deleting any file, adding any dependency, or affecting the database schema"
-- Session hygiene matters: new task = new session. Use /rewind instead of correcting mid-conversation. /compact at ~50% context, not 90%.
-- For complex tasks: use Template M. It handles scope, criteria, stop conditions, and session strategy in one structured block.
+- For complex tasks, use Template M. It handles scope, criteria, action boundaries, and progress evidence in one structured block.
+
+---
+
+**Codex CLI / ChatGPT Work / Codex IDE**
+- Use the GPT-5.6 route above. Sol is the capability-first default, Terra is the everyday workhorse, and Luna is best for clear, repeatable tasks.
+- Structure implementation prompts as Goal, Context, Scope, Constraints, Approval Boundaries, and Done. Include concrete verification commands when known.
+- Start with default reasoning. Raise it for work that needs deeper planning or checking; use Max for the hardest single-agent tasks and Ultra only when the task splits into meaningful independent tracks.
+- Keep one primary agent responsible for synthesis. Name each subagent's bounded deliverable and cap concurrency rather than requesting an open-ended swarm.
+- Ask for a concise rationale, evidence, changed-file summary, and verification results—not hidden reasoning.
 
 ---
 
@@ -384,8 +421,8 @@ Scan every user-provided prompt or rough idea for these failure patterns. Fix si
 - Entire codebase pasted as context → scope to the relevant file and function only
 
 **Reasoning failures**
-- Logic or analysis task with no step-by-step → add "Think through this carefully before answering"
-- CoT added to o3/o4-mini/R1/Qwen3-thinking → REMOVE IT
+- Logic or analysis task with no audit contract → request the conclusion, assumptions, decision criteria, evidence, verification checks, and remaining uncertainty
+- Any request for hidden chain-of-thought or private reasoning → REMOVE IT
 - New prompt contradicts prior session decisions → flag, resolve, include memory block
 
 **Agentic failures**
@@ -422,8 +459,7 @@ When the user's request references prior work, decisions, or session history —
 **Grounding anchors** — for any factual or citation task:
 "Use only information you are highly confident is accurate. If uncertain, write [uncertain] next to the claim. Do not fabricate citations or statistics."
 
-**Chain of Thought** — for logic, math, and debugging on standard reasoning models ONLY (Claude, GPT-5.x, Gemini, Qwen2.5, Llama). Never on o3/o4-mini/R1/Qwen3-thinking.
-"Think through this step by step before answering."
+**Auditable reasoning** — for logic, math, debugging, and analysis, request the conclusion, assumptions, evidence or intermediate results needed for audit, verification checks, and remaining uncertainty. Never request hidden chain-of-thought.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -493,4 +493,4 @@ Read only when the task requires it. Do not load both at once.
 | File | Read When |
 |------|-----------|
 | [references/templates.md](references/templates.md) | You need the full template structure for any tool category |
-| [references/patterns.md](references/patterns.md) | User pastes a bad prompt to fix, or you need the complete 35-pattern reference |
+| [references/patterns.md](references/patterns.md) | User pastes a bad prompt to fix, or you need the complete 37-pattern reference |

--- a/references/patterns.md
+++ b/references/patterns.md
@@ -61,8 +61,8 @@
 
 | # | Pattern | Bad Example | Fixed |
 |---|---------|------------|-------|
-| 26 | **No CoT for logic task** | "which approach is better?" | "Think through both approaches step by step before recommending" |
-| 27 | **Adding CoT to reasoning models** | "think step by step" sent to o1/o3 | Remove it — reasoning models think internally, CoT instructions degrade output |
+| 26 | **No audit contract for logic task** | "which approach is better?" | Request the recommendation, assumptions, decision criteria, evidence, and verification checks |
+| 27 | **Requesting hidden reasoning** | "show your chain of thought" | Remove it—ask for a concise rationale, evidence, and checks instead |
 | 28 | **Expecting inter-session memory** | "you already know my project" | Always re-provide the Memory Block in every new session |
 | 29 | **Contradicting prior work** | New prompt ignores earlier architecture | Include Memory Block with all established decisions |
 | 30 | **No grounding rule for factual tasks** | "summarize what experts say about X" | "Use only information you are highly confident is accurate. Say [uncertain] if not." |
@@ -78,5 +78,5 @@
 | 33 | **Silent agent** | No progress output | "After each step output: ✅ [what was completed]" |
 | 34 | **Unlocked filesystem** | No file restrictions | "Only edit files inside `src/`. Do not touch `package.json`, `.env`, or any config file." |
 | 35 | **No human review trigger** | Agent decides everything autonomously | "Stop and ask before: deleting any file, adding any dependency, or changing the database schema" |
-| 36 | **Vague first turn on Opus 4.7 / 4.8** | "fix the auth bug" with no scope, no files, no criteria | Opus 4.7 and 4.8 read prompts literally — they no longer fill implicit context like 4.6 did. Use Template M. Front-load intent, file scope, constraints, and acceptance criteria. |
-| 37 | **Context rot on long sessions** | Keeps correcting in the same session for 60+ turns | New task = new session. Use /rewind instead of correcting. /compact at ~50% context. Subagents for file-heavy investigation. |
+| 36 | **Vague first turn for an agentic model** | "fix the auth bug" with no scope, files, or criteria | Use Template M. Front-load the outcome, relevant context, file scope, constraints, action boundaries, and acceptance criteria. |
+| 37 | **Context rot on long sessions** | Repeats corrections while stale assumptions remain in context | Start a new session for unrelated work; otherwise compact around current decisions, constraints, failures, and target state. Delegate only independent, sizeable investigation. |

--- a/references/templates.md
+++ b/references/templates.md
@@ -10,7 +10,7 @@ Full template library for Prompt Master. Read the relevant template when the use
 | [B — CO-STAR](#template-b--co-star) | Professional documents, business writing |
 | [C — RISEN](#template-c--risen) | Complex multi-step projects |
 | [D — CRISPE](#template-d--crispe) | Creative work, brand voice |
-| [E — Chain of Thought](#template-e--chain-of-thought) | Logic, math, analysis, debugging |
+| [E — Auditable Reasoning](#template-e--auditable-reasoning) | Logic, math, analysis, debugging |
 | [F — Few-Shot](#template-f--few-shot) | Consistent structured output, pattern replication |
 | [G — File-Scope](#template-g--file-scope) | Cursor, Windsurf, Copilot — code editing AI |
 | [H — ReAct + Stop Conditions](#template-h--react--stop-conditions) | Claude Code, Devin — autonomous agents |
@@ -18,7 +18,7 @@ Full template library for Prompt Master. Read the relevant template when the use
 | [J — Reference Image Editing](#template-j--reference-image-editing) | Editing an existing image with a reference |
 | [K — ComfyUI](#template-k--comfyui) | ComfyUI node-based image workflows |
 | [L — Prompt Decompiler](#template-l--prompt-decompiler) | Breaking down, adapting, or splitting existing prompts |
-| [M — Opus 4.7 / 4.8 Task Brief](#template-m--opus-4.7--4.8-task-brief) | Complex, multi-step, or agentic task on Claude Opus 4.7 or 4.8 |
+| [M — Current Claude Task Brief](#template-m--current-claude-task-brief) | Complex, multi-step, or agentic task on current Claude models |
 
 ---
 
@@ -121,36 +121,32 @@ Experiment: Give 3 variants ranging from minimal to bold.
 
 ---
 
-## Template E — Chain of Thought
+## Template E — Auditable Reasoning
 
-*Use for logic-heavy tasks, math, debugging, and multi-factor analysis where the AI needs to reason carefully before committing to an answer.*
-
-**Important:** Only use CoT for standard reasoning models (Claude, GPT-4o, Gemini). Do NOT add CoT instructions to o1, o3, or Claude extended thinking — they reason internally and CoT instructions degrade their output.
+*Use for logic-heavy tasks, math, debugging, and multi-factor analysis where the result must be checkable without requesting private reasoning.*
 
 ```
 [Task statement]
 
-Before answering, think through this carefully:
-<thinking>
-1. What is the actual problem being asked?
-2. What constraints must the solution respect?
-3. What are the possible approaches?
-4. Which approach is best and why?
-</thinking>
+Return:
+1. Conclusion
+2. Assumptions
+3. Evidence or intermediate results needed to audit the conclusion
+4. Verification checks performed
+5. Remaining uncertainty, if any
 
-Give your final answer in <answer> tags only.
+Do not reveal hidden chain-of-thought or private reasoning. Keep the rationale concise and decision-relevant.
 ```
 
 **When to use:**
 - Debugging where the cause is not obvious
-- Comparing two technical approaches
-- Any math or calculation
-- Analysis where a wrong first impression is likely
+- Comparing technical approaches
+- Math or calculation requiring verification
+- Analysis where evidence and assumptions must be inspectable
 
 **When NOT to use:**
-- o1 / o3 / reasoning models (they think internally — adding CoT hurts)
-- Simple tasks where the answer is clear (unnecessary overhead)
-- Creative tasks (CoT can kill natural voice)
+- Simple tasks where the answer is clear
+- Creative tasks where an audit trail adds noise
 
 ---
 
@@ -396,9 +392,9 @@ Run these in order. Each output feeds the next.
 ```
 ---
 
-## Template M — Opus 4.7 / 4.8 Task Brief
+## Template M — Current Claude Task Brief
 
-*Use for any complex, multi-step, or agentic task on Claude Opus 4.7 or 4.8 (current default) — claude.ai, API, or Claude Code. Both read prompts literally and produce narrow output when context is missing. This template front-loads everything so the first turn is the only turn.*
+*Use for complex, multi-step, or agentic tasks on current Claude models—Claude.ai, API, or Claude Code. It front-loads the outcome, context, scope, and action boundaries while avoiding obsolete manual-thinking scaffolding.*
 
 ```
 ## Objective
@@ -423,21 +419,15 @@ Run these in order. Each output feeds the next.
 - [ ] [Binary check 2]
 - [ ] [Binary check 3]
 
-## Stop Conditions
-Stop and ask before:
-- Deleting any file
-- Adding any dependency
-- Modifying database schema or migrations
-- Touching anything outside Scope
+## Action Boundaries
+- Proceed with reversible, in-scope inspection, edits, and validation.
+- Stop and ask before destructive or irreversible actions, external writes, purchases, material scope expansion, or decisions that require user-only input.
 
-## Progress
-After each completed step: ✅ [what was done] — [file(s) affected]
+## Progress Evidence
+For long-running work, report progress only when it changes or when a checkpoint is reached. Ground every completion claim in a tool result, changed artifact, or verification output.
 ```
 
-**Thinking depth** — add only when needed, delete otherwise:
-- Hard multi-step task: `"Think carefully and step-by-step before starting."`
-- Simple targeted change: `"Prioritize responding quickly. This is a scoped change."`
-- Default: say nothing — adaptive thinking calibrates itself.
+**Effort** — configure in the API or harness rather than requesting private reasoning in the prompt. Start with the model default, lower it for routine scoped work, and raise it only when task difficulty warrants the cost.
 
 **Claude Code only — add Session Strategy block when relevant:**
 ```
@@ -445,8 +435,8 @@ After each completed step: ✅ [what was done] — [file(s) affected]
 [Pick one:]
 - New session — unrelated to prior context, start fresh
 - Continue — prior context still needed
-- Subagent — spin off for [file-heavy research / verification] so intermediate output stays out of main context
-- Compact first — run /compact [focus on X] then begin
+- Subagent — delegate only [independent, sizeable workstream], with a bounded deliverable
+- Compact first — compact around [decisions, constraints, and current state], then begin
 ```
 
-**When to use:** Opus 4.7 or 4.8 on any surface — claude.ai, API, Claude Code — when the task is complex, multi-file, ambiguous, or agentic. Not needed for simple one-shot tasks.
+**When to use:** Current Claude models on any surface when the task is complex, multi-file, ambiguous, or agentic. Not needed for simple one-shot tasks.


### PR DESCRIPTION
## Summary

- refresh Claude routing for Fable 5, Opus 5, Sonnet 5, Haiku 4.5, and current adaptive-thinking behavior
- refresh ChatGPT and Codex routing for GPT-5.6 Sol, Terra, and Luna while separating API controls from product-level Max, Pro, and Ultra options
- add first-class Grok 4.6 routing for reasoning effort, search grounding, tools, caching, and long agent loops
- add a model-recency gate so future "latest model" requests verify official provider docs instead of relying on stale hardcoded defaults
- replace hidden chain-of-thought prompting with an auditable-reasoning contract
- generalize the Claude task brief and synchronize the README's 13 templates and 37 patterns with the reference files

## Why

The current skill still assumes Opus 4.8 is Claude's default and has no dedicated Grok route. The static model guidance also needs a safe fallback for future releases.

Official references used:

- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5
- https://developers.openai.com/api/docs/guides/latest-model
- https://developers.openai.com/codex/models
- https://docs.x.ai/developers/models
- https://docs.x.ai/developers/grok-4-6

## Validation

- [x] `git diff --check`
- [x] YAML frontmatter keys present
- [x] Markdown code fences balanced
- [x] referenced local Markdown files exist
- [x] current model slugs present for Claude, GPT-5.6, and Grok 4.6
- [x] stale Opus 4.8 default and hidden-chain-of-thought template removed
- [x] no hardcoded credentials in added lines
- [x] independent review findings resolved
