### PR TITLE
fix: add license, author, and source metadata to SKILL.md frontmatter per Agent Skills spec

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: prompt-master
-version: 1.8.0
 description: Generates optimized prompts for AI tools. Activates only when the user explicitly asks to write, fix, improve, or adapt a prompt for a specific AI tool (LLM, Cursor, Midjourney, image AI, video AI, coding agents, etc.). Does not activate for general conversation, coding tasks, document writing, or other non-prompt-engineering work.
+license: MIT. See LICENSE for full text.
+metadata:
+  author: Nidhin Joseph Nelson
+  source: https://github.com/nidhinjs/prompt-master
+  version: "1.8.0"
 ---
 
 ## PRIMACY ZONE — Identity, Hard Rules, Output Lock


### PR DESCRIPTION
The current SKILL.md frontmatter has no author attribution, no license reference, and a bare version field that isn't part of the Agent Skills spec (only name, description, license, compatibility, metadata, and allowed-tools are recognized top-level fields). This adds a license field pointing to the repo's MIT LICENSE file, moves version into metadata, and adds author and source so the original creator and licensing terms are correctly surfaced on install. See https://agentskills.io/specification.